### PR TITLE
Add cursor line transparency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+﻿################################################################################
+# Diese .gitignore-Datei wurde von Microsoft(R) Visual Studio automatisch erstellt.
+################################################################################
+
+/CSVLintNppPlugin/obj
+/CSVLintNppPlugin/bin
+/.vs

--- a/CSVLintNppPlugin/CsvLint/CsvAnalyze.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvAnalyze.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using CSVLint.Tools;
 using CsvQuery.PluginInfrastructure;
 using Kbg.NppPluginNET.PluginInfrastructure;
@@ -95,7 +94,7 @@ namespace CSVLint
                     if (chr == ' ')
                     {
                         // more than 2 spaces could indicate new column
-                        if (++spaces > 1) bigSpaces.Increase((c + 1));
+                        if (++spaces > 1) bigSpaces.Increase(c + 1);
 
                         // one single space after a digit might be a new column
                         if (num == 1)
@@ -111,9 +110,9 @@ namespace CSVLint
                         spaces = 0;
 
                         // switch between alpha and numeric characters could indicate new column
-                        int checknum = ("0123456789".IndexOf(chr));
+                        int checknum = "0123456789".IndexOf(chr);
                         // ignore characters that can be both numeric or alpha values example "A.B." or "Smith-Johnson"
-                        int ignore = (".-+".IndexOf(chr));
+                        int ignore = ".-+".IndexOf(chr);
                         if (ignore < 0)
                         {
                             if (checknum < 0)
@@ -195,14 +194,14 @@ namespace CSVLint
                 result.TextQualifier = '\0';
 
             // head column name
-            result.ColNameHeader = (result.Separator != '\0');
+            result.ColNameHeader = result.Separator != '\0';
 
             // Exception, probably not tabular data file
             if ( (result.Separator == '\0') && ( (lineLengths.Count > 1) || (lineCount <= 1) ) )
             {
                 // check for typical XML characters
-                var xml1 = (occurrences.ContainsKey('>') ? occurrences['>'] : 0);
-                var xml2 = (occurrences.ContainsKey('<') ? occurrences['<'] : 0);
+                var xml1 = occurrences.ContainsKey('>') ? occurrences['>'] : 0;
+                var xml2 = occurrences.ContainsKey('<') ? occurrences['<'] : 0;
 
                 // check for binary characters, chr(31) or lower and not TAB
                 var bin = occurrences.Where(x => (int)x.Key < 32 && (int)x.Key != 9).Sum(x => x.Value);
@@ -270,7 +269,7 @@ namespace CSVLint
             // -----------------------------------------------------------------------------
 
             // reset string reader to first line is not possible, create a new one
-            bool fixedwidth = (result.Separator == '\0');
+            bool fixedwidth = result.Separator == '\0';
 
             var strdata = ScintillaStreams.StreamAllText();
 
@@ -287,16 +286,16 @@ namespace CSVLint
                 List<string> values = result.ParseNextLine(strdata);
 
                 // inspect all values
-                for (int i = 0; i < values.Count(); i++)
+                for (int i = 0; i < values.Count; i++)
                 {
                     // add columnstats if needed
-                    if (i > colstats.Count() - 1)
+                    if (i > colstats.Count - 1)
                     {
                         colstats.Add(new CsvAnalyzeColumn(i));
                     }
 
                     int fixedLength = -1;
-                    if (fixedwidth) fixedLength = (i < result.FieldWidths.Count ? result.FieldWidths[i] : values[i].Length);
+                    if (fixedwidth) fixedLength = i < result.FieldWidths.Count ? result.FieldWidths[i] : values[i].Length;
 
                     // next value to evaluate
                     colstats[i].InputData(values[i], fixedLength, false);
@@ -329,12 +328,12 @@ namespace CSVLint
             }
 
             // if all header Names (=frst row) comply with the column datatype, then there is no column names
-            result.ColNameHeader = (count > 0);
+            result.ColNameHeader = count > 0;
 
             // if no header column names rename all columns to "FIELD1", "FIELD2", "FIELD3" etc.
             if (!result.ColNameHeader)
             {
-                foreach (CSVLint.CsvColumn col in result.Fields) col.Name = string.Format("FIELD{0}", (col.Index + 1));
+                foreach (CsvColumn col in result.Fields) col.Name = string.Format("FIELD{0}", col.Index + 1);
             }
 
             // result
@@ -408,7 +407,7 @@ namespace CSVLint
 
             //List<CsvColumStats> colstats = new List<CsvColumStats>();
             int lineCount = 0;
-            bool fixedwidth = (csvdef.Separator == '\0');
+            bool fixedwidth = csvdef.Separator == '\0';
 
             var strdata = ScintillaStreams.StreamAllText();
 
@@ -422,10 +421,10 @@ namespace CSVLint
                 values = csvdef.ParseNextLine(strdata);
 
                 // inspect all values
-                for (int i = 0; i < values.Count(); i++)
+                for (int i = 0; i < values.Count; i++)
                 {
                     // add columnstats if needed
-                    if (i > colstats.Count() - 1)
+                    if (i > colstats.Count - 1)
                     {
                         colstats.Add(new CsvAnalyzeColumn(i));
                     }
@@ -450,14 +449,14 @@ namespace CSVLint
             IScintillaGateway editor = new ScintillaGateway(PluginBase.GetCurrentScintilla());
 
             string FILE_NAME = Path.GetFileName(notepad.GetCurrentFilePath());
-            string strhead = (csvdef.ColNameHeader ? " (+1 header line)" : "");
+            string strhead = csvdef.ColNameHeader ? " (+1 header line)" : "";
 
             sb.Append("Analyze dataset\r\n");
             sb.Append(string.Format("CSV Lint: v{0}\r\n", Main.GetVersion()));
             sb.Append(string.Format("File: {0}\r\n", FILE_NAME));
             sb.Append(string.Format("Date: {0}\r\n\r\n", DateTime.Now.ToString("dd-MMM-yyyy HH:mm")));
-            sb.Append(String.Format("Data records: {0}{1}\r\n", lineCount, strhead));
-            sb.Append(String.Format("Max.unique values: {0}\r\n", Main.Settings.UniqueValuesMax));
+            sb.Append(string.Format("Data records: {0}{1}\r\n", lineCount, strhead));
+            sb.Append(string.Format("Max.unique values: {0}\r\n", Main.Settings.UniqueValuesMax));
             sb.Append("\r\n");
 
 			// goal output, depending on data found:
@@ -480,29 +479,29 @@ namespace CSVLint
                 // next column
                 idx++;
                 sb.Append("----------------------------------------\r\n");
-                sb.Append(String.Format("{0}: {1}\r\n", idx, stats.Name));
+                sb.Append(string.Format("{0}: {1}\r\n", idx, stats.Name));
 
                 // count date types that were found
                 sb.Append("DataTypes      : ");
-                if (stats.CountDecimal  > 0) sb.Append(String.Format( "decimal ({0} = {1}%), ", stats.CountDecimal,  ReportPercentage(stats.CountDecimal,  lineCount)));
-                if (stats.CountInteger  > 0) sb.Append(String.Format( "integer ({0} = {1}%), ", stats.CountInteger,  ReportPercentage(stats.CountInteger,  lineCount)));
-                if (stats.CountString   > 0) sb.Append(String.Format(  "string ({0} = {1}%), ", stats.CountString,   ReportPercentage(stats.CountString,   lineCount)));
-                if (stats.CountDateTime > 0) sb.Append(String.Format("datetime ({0} = {1}%), ", stats.CountDateTime, ReportPercentage(stats.CountDateTime, lineCount)));
-                if (stats.CountEmpty    > 0) sb.Append(String.Format(   "empty ({0} = {1}%), ", stats.CountEmpty,    ReportPercentage(stats.CountEmpty,    lineCount)));
+                if (stats.CountDecimal  > 0) sb.Append(string.Format( "decimal ({0} = {1}%), ", stats.CountDecimal,  ReportPercentage(stats.CountDecimal,  lineCount)));
+                if (stats.CountInteger  > 0) sb.Append(string.Format( "integer ({0} = {1}%), ", stats.CountInteger,  ReportPercentage(stats.CountInteger,  lineCount)));
+                if (stats.CountString   > 0) sb.Append(string.Format(  "string ({0} = {1}%), ", stats.CountString,   ReportPercentage(stats.CountString,   lineCount)));
+                if (stats.CountDateTime > 0) sb.Append(string.Format("datetime ({0} = {1}%), ", stats.CountDateTime, ReportPercentage(stats.CountDateTime, lineCount)));
+                if (stats.CountEmpty    > 0) sb.Append(string.Format(   "empty ({0} = {1}%), ", stats.CountEmpty,    ReportPercentage(stats.CountEmpty,    lineCount)));
                 sb.Length -= 2; // remove last ", "
                 sb.Append("\r\n");
 
                 // width range
                 if (stats.MaxWidth > 0)
                 {
-                    var strwid = (stats.MinWidth == stats.MaxWidth ? stats.MaxWidth.ToString() : String.Format("{0} ~ {1}", stats.MinWidth, stats.MaxWidth));
-                    sb.Append(String.Format("Width range    : {0} characters\r\n", strwid));
+                    var strwid = stats.MinWidth == stats.MaxWidth ? stats.MaxWidth.ToString() : string.Format("{0} ~ {1}", stats.MinWidth, stats.MaxWidth);
+                    sb.Append(string.Format("Width range    : {0} characters\r\n", strwid));
                 }
 
                 // minimum maximum values
-                if (stats.CountInteger  > 0) sb.Append(String.Format("Integer range  : {0} ~ {1}\r\n", stats.stat_minint_org,  stats.stat_maxint_org));
-                if (stats.CountDecimal  > 0) sb.Append(String.Format("Decimal range  : {0} ~ {1}\r\n", stats.stat_mindbl_org,  stats.stat_maxdbl_org));
-                if (stats.CountDateTime > 0) sb.Append(String.Format("DateTime range : {0} ~ {1}\r\n", stats.stat_mindat_org,  stats.stat_maxdat_org));
+                if (stats.CountInteger  > 0) sb.Append(string.Format("Integer range  : {0} ~ {1}\r\n", stats.stat_minint_org,  stats.stat_maxint_org));
+                if (stats.CountDecimal  > 0) sb.Append(string.Format("Decimal range  : {0} ~ {1}\r\n", stats.stat_mindbl_org,  stats.stat_maxdbl_org));
+                if (stats.CountDateTime > 0) sb.Append(string.Format("DateTime range : {0} ~ {1}\r\n", stats.stat_mindat_org,  stats.stat_maxdat_org));
 
                 // if coded variable, unique values 
                 if ((stats.stat_uniquecount.Count > 0) && (stats.stat_uniquecount.Count <= Main.Settings.UniqueValuesMax))
@@ -514,11 +513,11 @@ namespace CSVLint
                     //stats.stat_uniquecount = stats.stat_uniquecount.OrderByDescending(obj => obj.Value).ToDictionary(obj => obj.Key, obj => obj.Value);
 
                     // list all unique values
-                    sb.Append(String.Format("-- Unique values ({0}) --\r\n", stats.stat_uniquecount.Count));
+                    sb.Append(string.Format("-- Unique values ({0}) --\r\n", stats.stat_uniquecount.Count));
                     foreach (var uqval in stats.stat_uniquecount)
                     {
-                        String strcount = uqval.Value.ToString();
-                        sb.Append(String.Format("n={0}: {1}\r\n", strcount.PadRight(13, ' '), uqval.Key));
+                        string strcount = uqval.Value.ToString();
+                        sb.Append(string.Format("n={0}: {1}\r\n", strcount.PadRight(13, ' '), uqval.Key));
                     }
                 }
 
@@ -532,9 +531,9 @@ namespace CSVLint
         /// Data statistical analysis report
         /// <param name="data"></param>
         /// <returns></returns>
-        private static String ReportPercentage(int iPart, int iTotal)
+        private static string ReportPercentage(int iPart, int iTotal)
         {
-            Double dPerc = (iPart * 100.0 / iTotal);
+            double dPerc = iPart * 100.0 / iTotal;
 
             return dPerc.ToString("0.0");
         }
@@ -546,7 +545,7 @@ namespace CSVLint
         public static void CountUniqueValues(CsvDefinition csvdef, List<int> colidx, bool sortBy, bool sortValue, bool sortDesc)
         {
             // examine data and keep list of counters per unique values
-            Dictionary<String, int> uniquecount = new Dictionary<String, int>();
+            Dictionary<string, int> uniquecount = new Dictionary<string, int>();
             var strdata = ScintillaStreams.StreamAllText();
             List<string> values;
 
@@ -558,16 +557,16 @@ namespace CSVLint
             {
                 // get next line of values
                 values = csvdef.ParseNextLine(strdata);
-                String uniq = "";
+                string uniq = "";
 
                 // get unique value(s) from column indexes
-                for (int i = 0; i < colidx.Count(); i++)
+                for (int i = 0; i < colidx.Count; i++)
                 {
                     // get index of selected column 
                     int col = colidx[i];
 
                     // if value contains separator character then put value in quotes
-                    var val = (col < values.Count ? values[col] : "");
+                    var val = col < values.Count ? values[col] : "";
                     if (val.IndexOf(csvdef.Separator) >= 0)
                     {
                         val = val.Replace("\"", "\"\"");
@@ -597,14 +596,14 @@ namespace CSVLint
             IScintillaGateway editor = new ScintillaGateway(PluginBase.GetCurrentScintilla());
 
             // get column names
-            for (int i = 0; i < colidx.Count(); i++)
+            for (int i = 0; i < colidx.Count; i++)
             {
                 // if column name contains separator character then put column name in quotes
-                var colname = (colidx[i] < csvdef.Fields.Count ? csvdef.Fields[colidx[i]].Name : "");
+                var colname = colidx[i] < csvdef.Fields.Count ? csvdef.Fields[colidx[i]].Name : "";
                 if (colname.IndexOf(csvdef.Separator) >= 0) colname = string.Format("\"{0}\"", colname);
 
                 // new header
-                sb.Append(String.Format("{0}{1}", colname, csvdef.Separator));
+                sb.Append(string.Format("{0}{1}", colname, csvdef.Separator));
 
                 // new csv defintion
                 csvnew.AddColumn(i, colname, csvdef.Fields[colidx[i]].MaxWidth, csvdef.Fields[colidx[i]].DataType, csvdef.Fields[colidx[i]].Mask);
@@ -623,9 +622,9 @@ namespace CSVLint
 
             // add all unique values, sort by count
             var maxwidth = 0;
-            foreach (KeyValuePair<String, int> unqcnt in uniquecount)
+            foreach (KeyValuePair<string, int> unqcnt in uniquecount)
             {
-                sb.Append(String.Format("{0}{1}{2}\r\n", unqcnt.Key, csvdef.Separator, unqcnt.Value));
+                sb.Append(string.Format("{0}{1}{2}\r\n", unqcnt.Key, csvdef.Separator, unqcnt.Value));
                 if (maxwidth < unqcnt.Value) maxwidth = unqcnt.Value;
             }
             csvnew.AddColumn("count_unique", maxwidth.ToString().Length, ColumnType.Integer);
@@ -635,7 +634,7 @@ namespace CSVLint
 
             // add csv def for this new list
             //Main.CSVChangeFileTab();
-            Main.updateCSVChanges(csvnew, false);
+            Main.UpdateCSVChanges(csvnew, false);
 
             // file content
             editor.SetText(sb.ToString());

--- a/CSVLintNppPlugin/CsvLint/CsvAnalyzeColumn.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvAnalyzeColumn.cs
@@ -2,21 +2,17 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CSVLint
 {
+    /// <summary>
+    /// Csv Analyze Column, keep stats from data, determine datatype width etc.
+    /// </summary>
     class CsvAnalyzeColumn
     {
-        /// <summary>
-        /// Csv Analyze Column, keep stats from data, determine datatype width etc.
-        /// </summary>
-        /// 
 
         // column statistics
-        public String Name = "";
+        public string Name = "";
         public int Index = 0;
         public int MinWidth = 9999;
         public int MaxWidth = 0;
@@ -54,18 +50,18 @@ namespace CSVLint
         // date format is unknown when no data read yet
         public int stat_dat_dmy = 0; // 0=unknown, 1=YMD, 2=DMY, 3=MDY, when beginning assume day-month order in dateformat is unknown until a value confirms either YMD or DMY or MDY
         public string stat_dat_format = ""; // most likely format
-        public DateTime stat_mindat_mdy;
-        public DateTime stat_maxdat_mdy;
-        public string stat_mindat_mdy_org = "";
-        public string stat_maxdat_mdy_org = "";
-        public Dictionary<String, int> stat_uniquecount = new Dictionary<String, int>();
+        //public DateTime stat_mindat_mdy;
+        //public DateTime stat_maxdat_mdy;
+        //public string stat_mindat_mdy_org = "";
+        //public string stat_maxdat_mdy_org = "";
+        public Dictionary<string, int> stat_uniquecount = new Dictionary<string, int>();
 
         public CsvAnalyzeColumn(int idx)
         {
             this.Index = idx;
         }
 
-        public void InputData(String data, int fixedLength, bool fullstats)
+        public void InputData(string data, int fixedLength, bool fullstats)
         {
             // count how many values
             this.CountAll++;
@@ -89,7 +85,7 @@ namespace CSVLint
             else
             {
                 // for fixed length files, the MaxWidth should be length of not-trimmed data
-                int length = (fixedLength > 0 ? fixedLength : data.Length);
+                int length = fixedLength > 0 ? fixedLength : data.Length;
 
                 // check for empty values, count empty strings
                 if (data.Length == 0)
@@ -244,7 +240,7 @@ namespace CSVLint
                         if (fullstats) KeepMinMaxDateTime(data, ddmax1, ddmax2, 3);
                     }
                     // or time, examples "9:00", "23:59:59", "23:59:59.000" etc.
-                    else if ((length >= 4) && (length <= 12) && (sep1 == ':') && (datesep >= 1) && (datesep <= 3) && (digits >= 3) && (digits <= 9) && (ddmax1 > 0) && ((ddmax1 <= 23) && (ddmax2 <= 59)))
+                    else if ((length >= 4) && (length <= 12) && (sep1 == ':') && (datesep >= 1) && (datesep <= 3) && (digits >= 3) && (digits <= 9) && (ddmax1 > 0) && (ddmax1 <= 23) && (ddmax2 <= 59))
                     {
                         this.CountDateTime++;
                         if (this.DateSep == '\0') this.DateSep = sep1;
@@ -302,7 +298,7 @@ namespace CSVLint
         /// <summary>
         /// Keep more stats only when running full analyze data report, not when scanning meta data
         /// </summary>
-        public void KeepMinMaxInteger(String value)
+        public void KeepMinMaxInteger(string value)
         {
             // try parse as integer
             if (int.TryParse(value, out int valint))
@@ -323,7 +319,7 @@ namespace CSVLint
             }
         }
 
-        public void KeepMinMaxDecimal(String value, char dec)
+        public void KeepMinMaxDecimal(string value, char dec)
         {
             // try parse as integer
             if (float.TryParse(value, out float valdbl))
@@ -344,14 +340,14 @@ namespace CSVLint
             }
         }
 
-        public void KeepMinMaxDateTime(String value, int ddmax1, int ddmax2, int datatype)
+        public void KeepMinMaxDateTime(string value, int ddmax1, int ddmax2, int datatype)
         {
             // TODO: this is not optimal, could still miss some minimum/maximum dates when initially assuming incorrect format
 
             // try to determine datetime format
             if (stat_dat_dmy == 0)
             {
-                bool newformat = (stat_dat_format == "");
+                bool newformat = stat_dat_format == "";
 
                 // date or datetime
                 if ((datatype == 1) || (datatype == 3))
@@ -435,7 +431,7 @@ namespace CSVLint
             }
         }
 
-        public void KeepUniqueValues(String value)
+        public void KeepUniqueValues(string value)
         {
             // when already found X unique values, no use in keep counting; probably not coded anyway
             if (stat_uniquecount.Count <= Main.Settings.UniqueValuesMax)
@@ -466,7 +462,7 @@ namespace CSVLint
             if ((this.CountInteger > 0) && (this.CountDecimal > 0))
             {
                 // decimal values ratio to integer values
-                var decratio = (1.0 * this.CountDecimal) / (this.CountInteger + this.CountDecimal);
+                var decratio = 1.0 * this.CountDecimal / (this.CountInteger + this.CountDecimal);
 
                 // if larger than 1 percent, example 10 decimal values and 990 integers
                 if (decratio > 0.01)
@@ -475,7 +471,7 @@ namespace CSVLint
                     this.CountDecimal += this.CountInteger;
                     this.CountInteger = 0;
                 }
-				// if less than 1% then interpret column as integers and decimals are errors in data
+                // if less than 1% then interpret column as integers and decimals are errors in data
             }
 
             // check if whole number integers (no decimals)
@@ -487,7 +483,7 @@ namespace CSVLint
             else if ((this.CountDecimal > this.CountString) && (this.CountDecimal > this.CountInteger) && (this.CountDecimal > this.CountDateTime))
             {
                 result.DataType = ColumnType.Decimal;
-                char dec = (this.CountDecimalPoint > this.CountDecimalComma ? '.' : ',');
+                char dec = this.CountDecimalPoint > this.CountDecimalComma ? '.' : ',';
 
                 // mask, example "9999.99"
                 mask = string.Format("{0}{1}{2}", mask.PadLeft(this.DecimalDigMax, '9'), dec, mask.PadLeft(this.DecimalDecMax, '9'));
@@ -571,25 +567,15 @@ namespace CSVLint
 
             result.MaxWidth = this.MaxWidth;
 
-            // add column 
+            // add column
             return result;
         }
-        public static String ColAsString(CsvColumn col)
+
+        public static string ColAsString(CsvColumn col)
         {
-
-            String str = "";
-
-            if (col.DataType == CSVLint.ColumnType.String)   str += "String";
-            if (col.DataType == CSVLint.ColumnType.Integer)  str += "Integer";
-            if (col.DataType == CSVLint.ColumnType.DateTime) str += "DateTime";
-            if (col.DataType == CSVLint.ColumnType.Decimal)  str += "Decimal";
-            if (col.DataType == CSVLint.ColumnType.Unknown)  str += "Unknown";
-
-            str = str + "\r\nwidth=" + col.MaxWidth + "\r\n";
-            str = str + "DecimalSymbol=" + col.DecimalSymbol + "\r\n";
-            str = str + "Decimals=" + col.Decimals + "\r\n";
-
-            return str;
+            return string.Format("{0}\r\nwidth={1}\r\nDecimalSymbol={2}\r\nDecimals={3}\r\n",
+                Enum.GetName(typeof(ColumnType), col.DataType),
+                col.MaxWidth, col.DecimalSymbol, col.Decimals);
         }
     }
 }

--- a/CSVLintNppPlugin/CsvLint/CsvDefinition.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvDefinition.cs
@@ -9,9 +9,7 @@ using Kbg.NppPluginNET;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace CSVLint
 {
@@ -78,13 +76,13 @@ namespace CSVLint
                 // get decimal position or -1 if not found
                 int pos1 = Mask.LastIndexOf('.');
                 int pos2 = Mask.LastIndexOf(',');
-                int p = (pos1 > pos2 ? pos1 : pos2);
+                int p = pos1 > pos2 ? pos1 : pos2;
 
                 // decimal character
-                this.DecimalSymbol = (pos1 > pos2 ? '.' : ',');
+                this.DecimalSymbol = pos1 > pos2 ? '.' : ',';
 
                 // sTag, thousand and decimand characters
-                this.sTag = (pos1 > pos2 ? ",." : ".,");
+                this.sTag = pos1 > pos2 ? ",." : ".,";
 
                 // iTag, max decimal places
                 this.iTag = this.Mask.Length - p - 1;
@@ -235,7 +233,7 @@ namespace CSVLint
                 // allow different datemask formats per column, but keep track of first datetime format as schema.ini global
 
                 // datetime column MUST have a mask
-                if (mask == "") mask = (this.DateTimeFormat == "" ? "yyyy-MM-dd" : this.DateTimeFormat);
+                if (mask == "") mask = this.DateTimeFormat == "" ? "yyyy-MM-dd" : this.DateTimeFormat;
 
                 // remember first datetime mask as the schema.ini global datetime mask
                 if (this.DateTimeFormat == "") this.DateTimeFormat = mask;
@@ -248,7 +246,7 @@ namespace CSVLint
                 int pos2 = mask.LastIndexOf(',');
 
                 if ( (pos1 >= 0) || (pos2 >= 0) ) {
-                    this.DecimalSymbol = (pos1 > pos2 ? '.' : ',');
+                    this.DecimalSymbol = pos1 > pos2 ? '.' : ',';
                     this.NumberDigits = mask.Length - (pos1 > pos2 ? pos1 : pos2) - 1;
                 }
             }
@@ -300,7 +298,7 @@ namespace CSVLint
             if ((pos1 < pos2) && (pos2 == namein.Length - 1))
             {
                 var strnr = namein.Substring(pos1 + 1, pos2 - pos1 - 1);
-                if (Int32.TryParse(strnr, out int inr))
+                if (int.TryParse(strnr, out int inr))
                 {
                     res = namein.Substring(0, pos1).Trim();
                     postfix = inr;
@@ -341,46 +339,58 @@ namespace CSVLint
             return namepart;
         }
 
-        // get csv definition from ini lines
+        /// <summary>
+        /// Create a new csv definition from ini lines.
+        /// </summary>
+        /// <param name="inilines">contains inifile sections
+        /// <example>"NumberDigits=1\nCol1=participant_id etc."</example></param>
         public CsvDefinition(string inilines)
         {
-            // inilines contains inifile sections example "NumberDigits=1\nCol1=participant_id etc."
-
             // get key values from  ini lines
-            var enstr = inilines.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
-               .Select(part => part.Split('='));
+            var enstr = inilines.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            Dictionary<string, string> result = new Dictionary<string, string>();
+            List<string> dup = new List<string>();
+            foreach (string line in enstr)
+            {
+                string[] parts = line.Split('=');
+                if(result.ContainsKey(parts[0]))
+                {
+                    dup.Add(parts[0]);
+                }
+                else
+                {
+                    result.Add(parts[0], parts[1]);
+                }
+            }
 
-            // check for duplicate keys before turning into dictionary
-            var dup = enstr.GroupBy(x => x[0])
-                          .Where(g => g.Count() > 1)
-                          .Select(y => y.Key)
-                          .ToList();
             if (dup.Count > 0)
             {
                 string errmsg = string.Format("Duplicate key(s) found ({0})", string.Join(",", dup));
-                throw new System.ArgumentException(errmsg);
+                throw new ArgumentException(errmsg);
                 //MessageBox.Show(errmsg, "Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
                 // create dictionary
-                Dictionary<String, String> keys = enstr.ToDictionary(split => split[0], split => split[1]);
-
-                // create dictionary
-                this.CsvDefInitFromKeys(keys);
+                this.CsvDefInitFromKeys(result);
             }
         }
-        public CsvDefinition(Dictionary<String, String> inikeys)
+
+        /// <summary>
+        /// Creates a new csv definition from key value pairs.
+        /// </summary>
+        /// <param name="inikeys">the key values pairs</param>
+        public CsvDefinition(Dictionary<string, string> inikeys)
         {
-            // inikeys contains key values pairs
             this.CsvDefInitFromKeys(inikeys);
         }
 
-        private void CsvDefInitFromKeys(Dictionary<String, String> inikeys)
+        private void CsvDefInitFromKeys(Dictionary<string, string> inikeys)
         {
             Fields = new List<CsvColumn>();
 
-            FieldWidths = new List<int>(); // TODO: really needed to also keep widths separate from Fields? because each Fields also contains a MaxWidth
+            // TODO: really needed to also keep widths separate from Fields? because each Fields also contains a MaxWidth
+            FieldWidths = new List<int>();
 
             // evaluate key values
             foreach (KeyValuePair<string, string> line in inikeys)
@@ -395,9 +405,9 @@ namespace CSVLint
                 {
                     // schema.ini structure
                     string k = line.Key.ToLower();
-                    string Val = line.Value.Trim();
-                    string vallow = Val.ToLower();
-                    int.TryParse(Val, out int vint);
+                    string val = line.Value.Trim();
+                    string vallow = val.ToLower();
+                    int.TryParse(val, out int vint);
 
                     // most important, what is the separator
                     if (k == "format")
@@ -410,7 +420,7 @@ namespace CSVLint
                         // custom character
                         if ((vallow.Substring(0, 10) == "delimited(") && (vallow.Substring(vallow.Length - 1, 1) == ")"))
                         {
-                            this.Separator = Val[10]; // first character after "Delimited("
+                            this.Separator = val[10]; // first character after "Delimited("
                         };
                     };
 
@@ -420,7 +430,7 @@ namespace CSVLint
                         // internally the datetime mask is c# format,         example "dd/MM/yyyy HH:mm"
                         // externally the datetime mask is schema.ini format, example "dd/mm/yyyy hh:nn"
                         // for full date format documentation see https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings?redirectedfrom=MSDN
-                        string tmp = Val;
+                        string tmp = val;
                         tmp = tmp.Replace("m", "M");
                         tmp = tmp.Replace("n", "m");
                         tmp = tmp.Replace("h", "H"); // hh=12h, HH=24h
@@ -428,18 +438,18 @@ namespace CSVLint
                     }
 
                     // schema.ini DecimalSymbol, typically ',' or '.' but can be set to any single character that is used to separate the integer from the fractional part of a number.
-                    if (k == "decimalsymbol") this.DecimalSymbol = Val[0];
+                    if (k == "decimalsymbol") this.DecimalSymbol = val[0];
 
                     // schema.ini NumberDigits, Indicates the number of decimal digits in the fractional portion of a number.
                     if (k == "numberdigits") this.NumberDigits = vint;
 
                     // schema.ini NumberLeadingZeros, 
                     // Specifies whether a decimal value less than 1 and more than -1 should contain leading zeros; this value can be either False (no leading zeros) or True.
-                    if (k == "numberleadingzeros") this.NumberLeadingZeros = (vallow[1] == 't');
+                    if (k == "numberleadingzeros") this.NumberLeadingZeros = vallow[1] == 't';
 
                     // schema.ini CurrencySymbol
                     // Indicates the currency symbol that can be used for currency values in the text file. Examples include the dollar sign ($) and Dm.
-                    if (k == "currencysymbol") this.CurrencySymbol = Val;
+                    if (k == "currencysymbol") this.CurrencySymbol = val;
 
                     // schema.ini CurrencyPosFormat
                     // Can be set to any of the following values:
@@ -447,7 +457,7 @@ namespace CSVLint
                     // - Currency symbol suffix with no separation(1$)
                     // - Currency symbol prefix with one character separation($ 1)
                     // - Currency symbol suffix with one character separation(1 $)
-                    if (k == "currencyposformat") this.CurrencyPosFormat = Val;
+                    if (k == "currencyposformat") this.CurrencyPosFormat = val;
 
                     // schema.ini CurrencyDigits
                     // Specifies the number of digits used for the fractional part of a currency amount.
@@ -457,20 +467,20 @@ namespace CSVLint
                     // Can be one of the following values:
                     // ($1)  -$1  $-1  $1 - (1$)  -1$  1 -$  1$- -1 $  -$ 1  1 $-  $ 1 -  $ -1  1 - $  ($ 1)  (1 $)
                     // This example shows the dollar sign, but you should replace it with the appropriate CurrencySymbol value in the actual program.
-                    if (k == "currencynegformat") this.CurrencyNegFormat = Val;
+                    if (k == "currencynegformat") this.CurrencyNegFormat = val;
 
                     // schema.ini CurrencyThousandSymbol
                     // Indicates the single-character symbol that can be used for separating currency values in the text file by thousands.
-                    if (k == "currencythousandsymbol") this.CurrencyThousandSymbol = Val[0];
+                    if (k == "currencythousandsymbol") this.CurrencyThousandSymbol = val[0];
 
                     // schema.ini CurrencyDecimalSymbol
                     // Can be set to any single character that is used to separate the whole from the fractional part of a currency amount.
-                    if (k == "currencydecimalsymbol") this.CurrencyDecimalSymbol = Val[0];
+                    if (k == "currencydecimalsymbol") this.CurrencyDecimalSymbol = val[0];
 
                     // schema.ini DecimalSymbol, typically ',' or '.' but can be set to any single character that is used to separate the integer from the fractional part of a number.
                     if (k == "colnameheader")
                     {
-                        this.ColNameHeader = (vallow[0] == 't');
+                        this.ColNameHeader = vallow[0] == 't';
                     } else
                     // schema.ini DateTimeFormat for all columns
                     if (k.Substring(0, 3) == "col")
@@ -479,7 +489,7 @@ namespace CSVLint
                         int idx = 0;
                         try
                         {
-                            idx = Int32.Parse(s) - 1;
+                            idx = int.Parse(s) - 1;
                         }
                         catch (FormatException)
                         {
@@ -500,11 +510,11 @@ namespace CSVLint
 
                         // NOT NULL must be at end of line
                         pos = vallow.LastIndexOf("not null");
-                        if (pos == Val.Count() - 8)
+                        if (pos == val.Length - 8)
                         {
-                            notnull = vallow.Substring(pos, Val.Length - pos);
-                            Val = Val.Substring(0, pos).Trim();
-                            vallow = Val.ToLower();
+                            notnull = vallow.Substring(pos, val.Length - pos);
+                            val = val.Substring(0, pos).Trim();
+                            vallow = val.ToLower();
                         }
 
                         // WIDTH must be at end of line
@@ -512,9 +522,9 @@ namespace CSVLint
                         pos = vallow.LastIndexOf("width");
                         if (pos == spc - 5)
                         {
-                            string width = vallow.Substring(pos, Val.Length - pos);
-                            Val = Val.Substring(0, pos).Trim();
-                            vallow = Val.ToLower();
+                            string width = vallow.Substring(pos, val.Length - pos);
+                            val = val.Substring(0, pos).Trim();
+                            vallow = val.ToLower();
 
                             width = width.Replace("width ", "");
                             if (int.TryParse(width, out int n))
@@ -531,8 +541,8 @@ namespace CSVLint
                         if (pos == -1) pos = vallow.LastIndexOf("int");
                         if ((pos >= 0) && (pos == spc + 1))
                         {
-                            datatypestr = vallow.Substring(pos, Val.Length - pos);
-                            Val = Val.Substring(0, pos).Trim();
+                            datatypestr = vallow.Substring(pos, val.Length - pos);
+                            val = val.Substring(0, pos).Trim();
                         }
                         // schema.ini datatype, string to ColumnType
                         if (datatypestr == "bit")      datatype = ColumnType.Integer;
@@ -565,25 +575,25 @@ namespace CSVLint
                             // data definition error; width shorter than nr of decimals
                             if (dig < 0) dig = 1;
 
-                            mask = string.Format("{0}{1}{2}", (new string('9', dig)), this.DecimalSymbol, (new string('9', dec)));
+                            mask = string.Format("{0}{1}{2}", new string('9', dig), this.DecimalSymbol, new string('9', dec));
                         };
 
                         // any left is the name of the column
-                        if (Val.Trim() != "") name = Val;
+                        if (val.Trim() != "") name = val;
 
                         // if quotes around name because of spaces
-                        int quote1 = Val.IndexOf('"');
-                        int quote2 = Val.LastIndexOf('"');
+                        int quote1 = val.IndexOf('"');
+                        int quote2 = val.LastIndexOf('"');
 
                         // check if incorrect and just one quote
                         if (quote1 == quote2)
                         {
-                            if (quote1 == 0) quote2 = Val.Length; // only quote at start
+                            if (quote1 == 0) quote2 = val.Length; // only quote at start
                             if (quote1 > 0) quote1 = -1;          // only quote at end
                         }
 
                         // if any quotes around name then remove them
-                        if (quote1 > 0 || quote2 > 0) name = Val.Substring(quote1 + 1, quote2 - quote1 - 1);
+                        if (quote1 > 0 || quote2 > 0) name = val.Substring(quote1 + 1, quote2 - quote1 - 1);
 
                         // add columns
                         this.AddColumn(idx, name, maxwidth, datatype, mask);
@@ -596,7 +606,7 @@ namespace CSVLint
                         string datatypestr = "";
                         try
                         {
-                            idxalt = Int32.Parse(s) - 1;
+                            idxalt = int.Parse(s) - 1;
                         }
                         catch (FormatException)
                         {
@@ -606,19 +616,19 @@ namespace CSVLint
                         ColumnType datatypealt = ColumnType.String;
 
                         // check for valid datatype must be at end of line
-                        int posalt = Val.LastIndexOf("DateTime");
+                        int posalt = val.LastIndexOf("DateTime");
                         if (posalt >= 0)
                         {
-                            int spcalt = Val.IndexOf(" ", posalt);
-                            datatypestr = Val.Substring(posalt, spcalt - posalt);
-                            Val = Val.Substring(spcalt, Val.Length - spcalt).Trim();
+                            int spcalt = val.IndexOf(" ", posalt);
+                            datatypestr = val.Substring(posalt, spcalt - posalt);
+                            val = val.Substring(spcalt, val.Length - spcalt).Trim();
                         }
-                        posalt = Val.LastIndexOf("Float");
+                        posalt = val.LastIndexOf("Float");
                         if (posalt >= 0)
                         {
-                            int spcalt = Val.IndexOf(" ", posalt);
-                            datatypestr = Val.Substring(posalt, spcalt - posalt);
-                            Val = Val.Substring(spcalt, Val.Length - spcalt).Trim();
+                            int spcalt = val.IndexOf(" ", posalt);
+                            datatypestr = val.Substring(posalt, spcalt - posalt);
+                            val = val.Substring(spcalt, val.Length - spcalt).Trim();
                         }
                         if (datatypestr == "DateTime") datatypealt = ColumnType.DateTime;
                         if (datatypestr == "Float") datatypealt = ColumnType.Decimal;
@@ -632,7 +642,7 @@ namespace CSVLint
                                 if (this.Fields[x].Index == idxalt)
                                 {
                                     this.Fields[x].DataType = datatypealt;
-                                    this.Fields[x].Mask = Val;
+                                    this.Fields[x].Mask = val;
                                     this.Fields[x].Initialize();
                                 }
                             };
@@ -771,7 +781,7 @@ namespace CSVLint
                     if (col.Decimals != this.NumberDigits)
                     {
                         // schma.ini doesn't support multiple floating point formats, i.e. with different amounts of decimals
-                        com = string.Format(";Col{0}={1} {2}\r\n", (i + 1), def, col.Mask);
+                        com = string.Format(";Col{0}={1} {2}\r\n", i + 1, def, col.Mask);
                     }
                 }
 
@@ -785,7 +795,7 @@ namespace CSVLint
                     else
                     {
                         // schma.ini doesn't support multiple datetime formats
-                        com = string.Format(";Col{0}={1} DateTime {2}\r\n", (i + 1), def, col.Mask);
+                        com = string.Format(";Col{0}={1} DateTime {2}\r\n", i + 1, def, col.Mask);
                         def += " Text";
                     }
                 }
@@ -794,7 +804,7 @@ namespace CSVLint
                 def += " Width " + col.MaxWidth;
 
                 // "Col1=LastName Text Width 50"
-                res += string.Format("Col{0}={1}\r\n", (i + 1), def);
+                res += string.Format("Col{0}={1}\r\n", i + 1, def);
 
                 // add alternative column format as comment
                 if (com != "") res += com;
@@ -848,13 +858,13 @@ namespace CSVLint
         ///     reformat file for date, decimal and separator
         /// </summary>
         /// <param name="data"> csv data </param>
-        public List<String> ParseNextLine(StreamReader strdata)
+        public List<string> ParseNextLine(StreamReader strdata)
         {
             // algorithm in part based on "How can I parse a CSV string with JavaScript, which contains comma in data?"
             // answer by user Bachor https://stackoverflow.com/a/58181757/1745616
 
             // return list
-            var res = new List<String>();
+            var res = new List<string>();
 
             StringBuilder value = new StringBuilder();
 
@@ -864,7 +874,7 @@ namespace CSVLint
 
                 // fixed width columns
                 int pos = 0;
-                int fieldcount = FieldWidths.Count()-1;
+                int fieldcount = FieldWidths.Count - 1;
                 for (int i = 0; i <= fieldcount; i++)
                 {
                     // next column width
@@ -906,7 +916,7 @@ namespace CSVLint
                     if (!quote)
                     {
                         // to catch where value is just two quotes "" right at start of line
-                        bool cellIsEmpty = (value.Length == 0);
+                        bool cellIsEmpty = value.Length == 0;
 
                         // check if starting a quoted value or going next column or going to next line
                         if ((cur == quote_char) && cellIsEmpty) { quote = true; wasquoted = true; }
@@ -958,9 +968,9 @@ namespace CSVLint
         /// <summary>
         ///  Based on the CsvDefinition, take array of data values and constructs one line of output
         /// </summary>
-        public String ConstructLine(string[] data)
+        public string ConstructLine(string[] data)
         {
-            String res = "";
+            string res = "";
 
             for (int c = 0; c < this.Fields.Count; c++)
             {

--- a/CSVLintNppPlugin/CsvLint/CsvEdit.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvEdit.cs
@@ -9,11 +9,9 @@ using Kbg.NppPluginNET;
 using Kbg.NppPluginNET.PluginInfrastructure;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace CSVLint
 {
@@ -21,7 +19,7 @@ namespace CSVLint
     {
 
         /// <summary>
-        ///     variable safe name, no spaces
+        /// variable safe name, no spaces
         /// </summary>
         public static string StringToVariable(string strinput)
         {
@@ -29,30 +27,30 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     apply quotes to value
+        /// apply quotes to value
         /// </summary>
-        public static string ApplyQuotesToString(String strinput, int ApplyCode, char Separator, ColumnType DataType)
+        public static string ApplyQuotesToString(string strinput, int applyCode, char separator, ColumnType dataType)
         {
             // default = none / minimal
-            bool apl = (strinput.IndexOf(Separator) >= 0);
+            bool apl = strinput.Contains(separator);
 
-            if ((ApplyCode > 0) && (apl == false))
+            if ((applyCode > 0) && !apl)
             {
-                apl = (   (ApplyCode == 1 && strinput.IndexOf(" ") >= 0)    // space
-                       || (ApplyCode == 2 && DataType == ColumnType.String) // string
-                       || (ApplyCode == 3 && DataType != ColumnType.Integer && DataType != ColumnType.Decimal) // non-numeric
-                       || (ApplyCode == 4) // all
-                       );
+                apl = (applyCode == 1 && strinput.IndexOf(" ") >= 0)    // space
+                   || (applyCode == 2 && dataType == ColumnType.String) // string
+                   || (applyCode == 3 && dataType != ColumnType.Integer && dataType != ColumnType.Decimal) // non-numeric
+                   || (applyCode == 4) // all
+                   ;
             }
 
             // apply quotes
-            if (apl) strinput = String.Format("\"{0}\"", strinput);
+            if (apl) strinput = string.Format("\"{0}\"", strinput);
 
             return strinput;
         }
 
         /// <summary>
-        ///     reformat file for date, decimal and separator
+        /// reformat file for date, decimal and separator
         /// </summary>
         /// <param name="data"> csv data </param>
         public static void ReformatDataFile(CsvDefinition csvdef, string reformatDatTime, string reformatDecimal, string reformatSeparator, bool updateSeparator, int ApplyQuotes, bool trimAll, bool align)
@@ -88,13 +86,13 @@ namespace CSVLint
 
             StringBuilder datanew = new StringBuilder();
 
-            char newSep = (updateSeparator ? reformatSeparator[0] : csvdef.Separator);
+            char newSep = updateSeparator ? reformatSeparator[0] : csvdef.Separator;
 
             // convert to fixed width, skip header line from source data because there is no room for column names in Fixed Width due to columns width can be 1 or 2 characters
-            bool skipheader = ((updateSeparator) && (newSep == '\0') && (csvdef.ColNameHeader));
+            bool skipheader = updateSeparator && (newSep == '\0') && csvdef.ColNameHeader;
 
             // convert from fixed width to separated values, add header line
-            if ((updateSeparator) && (newSep != '\0') && (!csvdef.ColNameHeader))
+            if (updateSeparator && (newSep != '\0') && (!csvdef.ColNameHeader))
             {
                 // add header column names
                 for (int c = 0; c < csvdef.Fields.Count; c++)
@@ -114,13 +112,13 @@ namespace CSVLint
                 linenr++;
 
                 // skip header line in source data, no header line in Fixed Width output data
-                if ((linenr == 1) && (skipheader)) continue;
+                if ((linenr == 1) && skipheader) continue;
 
                 // reformat data line to new line
                 for (int c = 0; c < values.Count; c++)
                 {
                     // next value
-                    String val = values[c];
+                    string val = values[c];
 
                     // fixed width align
                     int wid = val.Length;
@@ -156,7 +154,7 @@ namespace CSVLint
                         tmpColumnType = csvdef.Fields[c].DataType;
 
                         // align vertically OR fixed width, text align left - numeric align right
-                        wid = (align ? alignwidths[c] : csvdef.Fields[c].MaxWidth);
+                        wid = align ? alignwidths[c] : csvdef.Fields[c].MaxWidth;
                         alignleft = !((tmpColumnType == ColumnType.Integer) || (tmpColumnType == ColumnType.Decimal));
 
                         // exception for header -> always left align
@@ -209,7 +207,7 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     update all date columns to new date format
+        /// update all date columns to new date format
         /// </summary>
         public static void ConvertToSQL(CsvDefinition csvdef)
         {
@@ -219,7 +217,7 @@ namespace CSVLint
 
             // if csv already contains "_record_number"
             var recidname = csvdef.GetUniqueColumnName("_record_number", out int postfix);
-            if (postfix > 0) recidname = String.Format("{0} ({1})", recidname, postfix);
+            if (postfix > 0) recidname = string.Format("{0} ({1})", recidname, postfix);
 
             // get access to Notepad++
             INotepadPPGateway notepad = new NotepadPPGateway();
@@ -232,7 +230,7 @@ namespace CSVLint
             sb.Append(string.Format("-- CSV Lint plug-in v{0}\r\n", VERSION_NO));
             sb.Append(string.Format("-- File: {0}\r\n", FILE_NAME));
             sb.Append(string.Format("-- Date: {0}\r\n", DateTime.Now.ToString("dd-MMM-yyyy HH:mm")));
-            sb.Append(string.Format("-- SQL ANSI: {0}\r\n", (Main.Settings.SQLansi ? "mySQL" : "MS-SQL")));
+            sb.Append(string.Format("-- SQL ANSI: {0}\r\n", Main.Settings.SQLansi ? "mySQL" : "MS-SQL"));
             sb.Append("-- -------------------------------------\r\n");
             sb.Append(string.Format("CREATE TABLE {0}(\r\n\t", TABLE_NAME));
 
@@ -245,7 +243,7 @@ namespace CSVLint
             for (var r = 0; r < csvdef.Fields.Count; r++)
             {
                 // determine sql column name -> mySQL = `colname`, MS-SQL = [colname]
-                string sqlname = string.Format((Main.Settings.SQLansi ? "`{0}`" : "[{0}]"), csvdef.Fields[r].Name);
+                string sqlname = string.Format(Main.Settings.SQLansi ? "`{0}`" : "[{0}]", csvdef.Fields[r].Name);
 
                 // determine sql datatype
                 var sqltype = "varchar";
@@ -273,7 +271,7 @@ namespace CSVLint
                 //    csvdef.Fields[r].Mask = masknew.Trim();
                 //}
 
-                sb.Append(String.Format("{0} {1}", sqlname, sqltype));
+                sb.Append(string.Format("{0} {1}", sqlname, sqltype));
                 cols += sqlname;
                 if (r < csvdef.Fields.Count - 1)
                 {
@@ -290,7 +288,7 @@ namespace CSVLint
             // use stringreader to go line by line
             var strdata = ScintillaStreams.StreamAllText();
 
-            int lineCount = (csvdef.ColNameHeader ? -1 : 0);
+            int lineCount = csvdef.ColNameHeader ? -1 : 0;
             int batchcomm = -1;  // batch comment line
             int batchstart = -1; // batch starting line
 
@@ -351,11 +349,11 @@ namespace CSVLint
                         }
                         else if (csvdef.Fields[r].DataType == ColumnType.Decimal)
                         {
-                            str = str.Replace((csvdef.Fields[r].DecimalSymbol == '.' ? "," : "."), ""); // remove thousand separator
+                            str = str.Replace(csvdef.Fields[r].DecimalSymbol == '.' ? "," : ".", ""); // remove thousand separator
                             str = str.Replace(csvdef.Fields[r].DecimalSymbol, '.');
                         }
                         else if ((csvdef.Fields[r].DataType == ColumnType.String)
-                                || (csvdef.Fields[r].DataType == ColumnType.DateTime))
+                              || (csvdef.Fields[r].DataType == ColumnType.DateTime))
                         //|| (csvdef.Fields[r].DataType == ColumnType.Guid))
                         {
                             // sql datetime format
@@ -401,9 +399,9 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     reformat file for date, decimal and separator
+        /// reformat file for date, decimal and separator
         /// </summary>
-        /// <param name="data"> csv data </param>
+        /// <param name="data">csv data</param>
         public static void ColumnSplit(CsvDefinition csvdef, int ColumnIndex, int SplitCode, string Parameter1, string Parameter2, bool bRemove)
         {
             // handle to editor
@@ -418,8 +416,8 @@ namespace CSVLint
             var IntPar2 = -1 * IntPar;
 
             // decode
-            List<String> decode1 = new List<String>();
-            List<String> decode2 = new List<String>();
+            List<string> decode1 = new List<string>();
+            List<string> decode2 = new List<string>();
 
             // decode
             if (SplitCode == 5)
@@ -456,10 +454,10 @@ namespace CSVLint
                         var newname = csvdef.GetUniqueColumnName(csvdef.Fields[c].Name, out int postfix);
 
                         // when decoding csv values (SplitCode == 5) add more new columns, when normal split then just 2
-                        var addmax = (SplitCode == 5 ? decode1.Count + 1 : 2); // +1 = one extra column of any left-over values
+                        var addmax = SplitCode == 5 ? decode1.Count + 1 : 2; // +1 = one extra column of any left-over values
                         for (var cnew = 0; cnew < addmax; cnew++)
                         {
-                            datanew.Append(String.Format("{0}{1} ({2})", sep, newname, postfix + cnew));
+                            datanew.Append(string.Format("{0}{1} ({2})", sep, newname, postfix + cnew));
                         }
                     }
                 }
@@ -478,7 +476,7 @@ namespace CSVLint
                 for (int c = 0; c < values.Count; c++)
                 {
                     // next value
-                    String val = values[c];
+                    string val = values[c];
 
                     // if value contains separator character then put value in quotes
                     if (val.IndexOf(sep) >= 0) val = string.Format("\"{0}\"", val);
@@ -493,9 +491,9 @@ namespace CSVLint
                     // add new split columns values
                     if (c == ColumnIndex)
                     {
-                        String val0 = values[c]; // original value without quotes
-                        String val1 = val0;
-                        String val2 = "";
+                        string val0 = values[c]; // original value without quotes
+                        string val1 = val0;
+                        string val2 = "";
 
                         // how to split value
                         if (SplitCode == 1)
@@ -607,7 +605,7 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     update all date columns to new date format
+        /// update all date columns to new date format
         /// </summary>
         public void UpdateAllDateFormat()
         {
@@ -617,7 +615,7 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     update all decimal columns to new decimal format
+        /// update all decimal columns to new decimal format
         /// </summary>
         public void UpdateAllDecimal()
         {
@@ -625,7 +623,7 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     update a single column to new data type
+        ///update a single column to new data type
         /// </summary>
         public void UpdateColumn()
         {
@@ -633,7 +631,7 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     split invalid values of column into a new column
+        /// split invalid values of column into a new column
         /// </summary>
         public void SplitColumn()
         {

--- a/CSVLintNppPlugin/CsvLint/CsvGenerateCode.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvGenerateCode.cs
@@ -8,29 +8,26 @@ using CsvQuery.PluginInfrastructure;
 using Kbg.NppPluginNET.PluginInfrastructure;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CSVLint
 {
     class CsvGenerateCode
     {
-		
+
         /// <summary>
-        ///		determine short variable names based on column names
+        /// determine short variable names based on column names
         /// </summary>
         /// <param name="data"> csv data </param>
         public void DetermineVariableNames(string data)
         {
             // shorten variable names based on column names
         }
-		
+
         /// <summary>
-        ///		determine short variable names based on column names
+        /// determine short variable names based on column names
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String HeaderComment()
+        public string HeaderComment()
         {
             // default comment for all scripts
             //return "Generated using Notepad++ CSV Lint plug-in"
@@ -42,89 +39,89 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     generate Python code based on columns (most asked on stackoverflow
+        /// generate Python code based on columns (most asked on stackoverflow)
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GeneratePython(string data)
+        public string GeneratePython(string data)
         {
             return "Python";
         }
-		
+
         /// <summary>
-        ///     generate Python Panda code based on columns (most asked on stackoverflow
+        /// generate Python Panda code based on columns (most asked on stackoverflow)
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GeneratePythonPanda(string data)
+        public string GeneratePythonPanda(string data)
         {
-			// fixed
-			// import pandas
-			// # Using Pandas with a column specification
-			// col_specification = [(0, 20), (21, 30), (31, 50), (51, 100)]
-			// data = pandas.read_fwf(path, colspecs=col_specification)
+            // fixed
+            // import pandas
+            // # Using Pandas with a column specification
+            // col_specification = [(0, 20), (21, 30), (31, 50), (51, 100)]
+            // data = pandas.read_fwf(path, colspecs=col_specification)
 
-			// separator
-			//import pandas
-			//df = pandas.read_csv('hrdata.csv', 
-			//            index_col='Employee', 
-			//            parse_dates=['Hired'],
-			//            sep=';',
-			//            header=0, 
-			//            names=['Employee', 'Hired', 'Salary', 'Sick Days'])
-			//df.to_csv('hrdata_modified.csv')
+            // separator
+            //import pandas
+            //df = pandas.read_csv('hrdata.csv', 
+            //            index_col='Employee', 
+            //            parse_dates=['Hired'],
+            //            sep=';',
+            //            header=0, 
+            //            names=['Employee', 'Hired', 'Salary', 'Sick Days'])
+            //df.to_csv('hrdata_modified.csv')
 
             return "Python Panda";
         }
 
         /// <summary>
-        ///     generate SPSS code based on columns
+        /// generate SPSS code based on columns
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GenerateSPSS(string data)
+        public string GenerateSPSS(string data)
         {
             return "SPSS";
         }
 
         /// <summary>
-        ///     generate SQL based on columns
+        /// generate SQL based on columns
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GenerateSQL(string data)
+        public string GenerateSQL(string data)
         {
             return "SQL";
         }
-		
+
         /// <summary>
-        ///     generate schema.ini based on columns
+        /// generate schema.ini based on columns
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GenerateSchemaIni(string data)
+        public string GenerateSchemaIni(string data)
         {
             return "schema.ini";
         }
-		
+
         /// <summary>
-        ///     generate R-scripting code based on columns
+        /// generate R-scripting code based on columns
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GenerateRScript(string data)
+        public string GenerateRScript(string data)
         {
             return "R script";
         }
 
         /// <summary>
-        ///     generate PowerShell script based on columns
+        /// generate PowerShell script based on columns
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GeneratePowerShell(string data)
+        public string GeneratePowerShell(string data)
         {
             return "PowerShell";
         }
-		
+
         /// <summary>
-        ///     generate PHP code based on columns
+        /// generate PHP code based on columns
         /// </summary>
         /// <param name="data"> csv data </param>
-        public String GeneratePHP(string data)
+        public string GeneratePHP(string data)
         {
             return "PHP";
         }

--- a/CSVLintNppPlugin/CsvLint/CsvSchemaIni.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvSchemaIni.cs
@@ -1,27 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 
 namespace CSVLintNppPlugin.CsvLint
 {
     class CsvSchemaIni
     {
-        public static Dictionary<String, String> ReadIniSection(string FilePath)
+        public static Dictionary<string, string> ReadIniSection(string filePath)
         {
             // file name and path of schema.ini
-            var path = Path.GetDirectoryName(FilePath);
-            var file = Path.GetFileName(FilePath);
+            var path = Path.GetDirectoryName(filePath);
+            var file = Path.GetFileName(filePath);
 
             // schema.ini and section name
-            var inifile = String.Format("{0}\\{1}", path, "schema.ini");
-            var section = String.Format("[{0}]", file.ToLower());
+            var inifile = Path.Combine(path, "schema.ini");
+            var section = string.Format("[{0}]", file.ToLower());
 
             // read entire ini file and look for section
-            var inilines = new Dictionary<String, String>();
+            var inilines = new Dictionary<string, string>();
 
             // not a new file that hasn't been saved yet
-            if ( (path != "") && (File.Exists(inifile)) )
+            if ( (path != "") && File.Exists(inifile) )
             {
                 using (StreamReader reader = new StreamReader(inifile))
                 {
@@ -29,27 +28,25 @@ namespace CSVLintNppPlugin.CsvLint
                     bool bSec = false;
                     while ((line = reader.ReadLine()) != null)
                     {
-                        if (line != "")
+                        if (string.IsNullOrEmpty(line)) continue;
+                        // check section
+                        if (line[0] == '[')
                         {
-                            // check section
-                            if (line[0] == '[')
+                            // check current section and inilines index
+                            bSec = line.ToLower() == section;
+                        }
+                        else if (bSec)
+                        {
+                            var spl = line.Split('=');
+                            var key = line;
+                            var val = "";
+                            if (spl.Length > 1)
                             {
-                                // check current section and inilines index
-                                bSec = (line.ToLower() == section);
+                                key = spl[0];
+                                val = spl[1];
                             }
-                            else if (bSec)
-                            {
-                                var spl = line.Split('=');
-                                var key = line;
-                                var val = "";
-                                if (spl.Length > 1)
-                                {
-                                    key = spl[0];
-                                    val = spl[1];
-                                }
 
-                                inilines.Add(key, val);
-                            }
+                            inilines.Add(key, val);
                         }
                     }
                 }
@@ -66,11 +63,11 @@ namespace CSVLintNppPlugin.CsvLint
             errmsg = "";
 
             // schema.ini and section name
-            var inifile = String.Format("{0}\\{1}", path, "schema.ini");
-            var section = String.Format("[{0}]", file.ToLower());
+            var inifile = string.Format("{0}\\{1}", path, "schema.ini");
+            var section = string.Format("[{0}]", file.ToLower());
 
             // read entire ini file and look for section
-            var inilines = new List<String>();
+            var inilines = new List<string>();
             int idx = -1;
 
             // check if schema.ini exists
@@ -88,7 +85,7 @@ namespace CSVLintNppPlugin.CsvLint
                             if (line[0] == '[')
                             {
                                 // check current section and inilines index
-                                bSec = (line.ToLower() == section);
+                                bSec = line.ToLower() == section;
                                 if (bSec) idx = inilines.Count;
                             }
                         }
@@ -107,7 +104,7 @@ namespace CSVLintNppPlugin.CsvLint
             }
 
             // section header
-            inilines.Insert(idx + 0, String.Format("[{0}]", file));
+            inilines.Insert(idx + 0, string.Format("[{0}]", file));
             inilines.Insert(idx + 1, inikeys);
             //inilines.Insert(idx + 2, ""); // add one more empty line to separate next section
 

--- a/CSVLintNppPlugin/CsvLint/CsvSchemaIni.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvSchemaIni.cs
@@ -6,21 +6,35 @@ namespace CSVLintNppPlugin.CsvLint
 {
     class CsvSchemaIni
     {
+        /// <summary>
+        /// the name of the file to store the schema informations
+        /// </summary>
+        /// <remarks>all schema informations of edited files of
+        /// any directory will be stored in the schema.ini of
+        /// that directory</remarks>
+        private const string INI_NAME = "schema.ini";
+
+        /// <summary>
+        /// Reads the CSV definition for the given file.
+        /// </summary>
+        /// <param name="filePath">the full name of the file to be edited</param>
+        /// <returns>the contents of the schema.ini in the directory
+        /// of the given filename</returns>
         public static Dictionary<string, string> ReadIniSection(string filePath)
         {
-            // file name and path of schema.ini
-            var path = Path.GetDirectoryName(filePath);
-            var file = Path.GetFileName(filePath);
+            // file name and path of the file to be edited
+            string path = Path.GetDirectoryName(filePath);
+            string file = Path.GetFileName(filePath);
 
             // schema.ini and section name
-            var inifile = Path.Combine(path, "schema.ini");
-            var section = string.Format("[{0}]", file.ToLower());
+            string inifile = Path.Combine(path, INI_NAME);
+            string section = string.Format("[{0}]", file.ToLower());
 
             // read entire ini file and look for section
             var inilines = new Dictionary<string, string>();
 
             // not a new file that hasn't been saved yet
-            if ( (path != "") && File.Exists(inifile) )
+            if ( (!string.IsNullOrEmpty(path)) && File.Exists(inifile) )
             {
                 using (StreamReader reader = new StreamReader(inifile))
                 {
@@ -55,16 +69,23 @@ namespace CSVLintNppPlugin.CsvLint
             return inilines;
         }
 
-        public static bool WriteIniSection(string FilePath, string inikeys, out string errmsg)
+        /// <summary>
+        /// Writes the given CSV definition for the given file.
+        /// </summary>
+        /// <param name="filePath">the full name of the edited file</param>
+        /// <param name="inikeys">the textual representation of the CSV definition</param>
+        /// <param name="errmsg">an error message if an error occured else empty string</param>
+        /// <returns>true when no error occured</returns>
+        public static bool WriteIniSection(string filePath, string inikeys, out string errmsg)
         {
-            // file name and path of schema.ini
-            var path = Path.GetDirectoryName(FilePath);
-            var file = Path.GetFileName(FilePath);
-            errmsg = "";
+            errmsg = string.Empty;
+            // file name and path of the edited file
+            string path = Path.GetDirectoryName(filePath);
+            string file = Path.GetFileName(filePath);
 
             // schema.ini and section name
-            var inifile = string.Format("{0}\\{1}", path, "schema.ini");
-            var section = string.Format("[{0}]", file.ToLower());
+            string inifile = Path.Combine(path, INI_NAME);
+            string section = string.Format("[{0}]", file.ToLower());
 
             // read entire ini file and look for section
             var inilines = new List<string>();
@@ -79,7 +100,7 @@ namespace CSVLintNppPlugin.CsvLint
                     bool bSec = false;
                     while ((line = reader.ReadLine()) != null)
                     {
-                        if (line != "")
+                        if (line.Length > 0)
                         {
                             // check section
                             if (line[0] == '[')

--- a/CSVLintNppPlugin/CsvLint/CsvValidate.cs
+++ b/CSVLintNppPlugin/CsvLint/CsvValidate.cs
@@ -9,9 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace CSVLint
 {
@@ -44,7 +42,7 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     validate csv data against the definition of a CsvDefinition 
+        /// validate csv data against the definition of a CsvDefinition
         /// </summary>
         /// <param name="strdata"> csv data </param>
         public void ValidateData(StreamReader strdata, CsvDefinition csvdef)
@@ -96,7 +94,7 @@ namespace CSVLint
                 // too many or too few columns
                 if (values.Count != csvdef.Fields.Count)
                 {
-                    err += string.Format("Too {0} columns, ", (values.Count > csvdef.Fields.Count ? "many" : "few"));
+                    err += string.Format("Too {0} columns, ", values.Count > csvdef.Fields.Count ? "many" : "few");
                     counterr++;
                 }
 
@@ -104,7 +102,7 @@ namespace CSVLint
                 for (var i = 0; i < values.Count; i++)
                 {
                     // next value and column number
-                    String val = values[i];
+                    string val = values[i];
 
                     // adjust for quoted values, trim first because can be a space before the first quote, example .., "BMI",..
                     var valtrim = val.Trim();
@@ -156,12 +154,12 @@ namespace CSVLint
             var dtElapsed = (DateTime.Now - dtStart).ToString(@"hh\:mm\:ss\.fff");
 
             // final ready message
-            var line = string.Format("Inspected {0} lines, {1} data errors found, time elapsed {2}", lineCount, (this.log.Count == 0 ? "no" : counterr.ToString()), dtElapsed);
+            var line = string.Format("Inspected {0} lines, {1} data errors found, time elapsed {2}", lineCount, this.log.Count == 0 ? "no" : counterr.ToString(), dtElapsed);
             this.log.Add(new LogLine(line, -1, -1));
         }
 
         /// <summary>
-        ///     validate csv data against the definition of a CsvDefinition 
+        /// validate csv data against the definition of a CsvDefinition 
         /// </summary>
         /// <param name="data"> csv data </param>
         public string EvaluateDataValue(string val, CsvColumn coldef, int idx)
@@ -219,14 +217,14 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     validate integer value
-        ///     Use custom function instead of using the standard `int.TryParse(val, out _);`
-        ///     which allows for max integer of 2147483647 (32bit) or 9223372036854775807 (64bit)
-        ///     
-        ///     This custom function gives the same result regardless of 32bit/64bit bytecode
-        ///     and only depends on the `IntegerDigitsMax` setting
-        ///     so that it will also correctly detect bigint/large int and even googolplex values
-        ///     (For typical datasets this function also performs faster, though only slightly; 180ns vs 160ns)
+        /// validate integer value
+        /// Use custom function instead of using the standard `int.TryParse(val, out _);`
+        /// which allows for max integer of 2147483647 (32bit) or 9223372036854775807 (64bit)
+        /// 
+        /// This custom function gives the same result regardless of 32bit/64bit bytecode
+        /// and only depends on the `IntegerDigitsMax` setting
+        /// so that it will also correctly detect bigint/large int and even googolplex values
+        /// (For typical datasets this function also performs faster, though only slightly; 180ns vs 160ns)
         /// </summary>
         /// <param name="val"> integer value, examples "1", "23", "-456" etc.</param>
         private bool EvaluateInteger(string val)
@@ -260,14 +258,14 @@ namespace CSVLint
         }
 
         /// <summary>
-        ///     validate decimal value
-        ///     Use custom function instead of using the standard `float.TryParse(val, out _);`
-        ///     
-        ///     This custom function gives the same result regardless of 32bit/64bit bytecode
-        ///     and only depends on the `DecimalDigitsMax` setting
-        ///     so that it will also correctly detect values with lots of decimals
-        ///     and also detect incorrect thousand separators for example "123,45,678.00"
-        ///     (For typical datasets this function also performs faster; 320ns vs 180ns)
+        /// validate decimal value
+        /// Use custom function instead of using the standard `float.TryParse(val, out _);`
+        /// 
+        /// This custom function gives the same result regardless of 32bit/64bit bytecode
+        /// and only depends on the `DecimalDigitsMax` setting
+        /// so that it will also correctly detect values with lots of decimals
+        /// and also detect incorrect thousand separators for example "123,45,678.00"
+        /// (For typical datasets this function also performs faster; 320ns vs 180ns)
         /// </summary>
         /// <param name="val"> decimal value, example "1.23", "-4,56", ".5" etc.</param>
         //private bool EvaluateDecimal(string val, CsvColumn coldef, out string err)
@@ -351,7 +349,7 @@ namespace CSVLint
             }
 
             // example ".25" or "-.5"
-            if ((decsep - sign == 1) && (Main.Settings.DecimalLeadingZero))
+            if ((decsep - sign == 1) && Main.Settings.DecimalLeadingZero)
             {
                 err += "missing leading zero not allowed";
                 isDecimal = false;
@@ -382,10 +380,10 @@ namespace CSVLint
                 // check year range
                 int year = dateValue.Year;
                 if (year < Main.Settings.YearMinimum || year > Main.Settings.YearMaximum)
-				{
+                {
                     isDate = false;
                     err = "is out of range";
-				};
+                };
             };
 
             return isDate;

--- a/CSVLintNppPlugin/Forms/AboutForm.cs
+++ b/CSVLintNppPlugin/Forms/AboutForm.cs
@@ -13,7 +13,7 @@ namespace Kbg.NppPluginNET
         {
             InitializeComponent();
 
-            String ver = Main.GetVersion();
+            string ver = Main.GetVersion();
             lblTitle.Text += ver;
 
             // tooltip initialization
@@ -54,25 +54,25 @@ namespace Kbg.NppPluginNET
             return 0; // not Easter day
         }
         private void DisplayEasterEgg()
-		{
+        {
             // display easter egg icon on certain dates
             DateTime today = DateTime.Now.AddHours(-3); // day 'starts' in the morning and lasts after midnight (especially for new years eve etc.)
 
-            String msg = "";
-            String obj = "";
+            string msg = "";
+            string obj = "";
             Image img = CSVLintNppPlugin.Properties.Resources.easteregg;
 
             int easter = IsEaster(today);
             if (easter > 0)
             {
                 // March/April ?th, varies
-                msg = String.Format("Easter {0}day", (easter == 1 ? "Sun" : "Mon"));
+                msg = string.Format("Easter {0}day", easter == 1 ? "Sun" : "Mon");
                 obj = "an Easter egg";
                 img = CSVLintNppPlugin.Properties.Resources.easteregg;
             }
             else
             {
-                int daymonth = (today.Month * 100 + today.Day);
+                int daymonth = today.Month * 100 + today.Day;
 
                 switch (daymonth)
                 {
@@ -98,7 +98,7 @@ namespace Kbg.NppPluginNET
             // initialization easter egg
             if (msg != "")
             {
-                String tip = String.Format("Happy {0}! You've found {1} ;)", msg, obj);
+                string tip = string.Format("Happy {0}! You've found {1} ;)", msg, obj);
                 helperTip.SetToolTip(picEasterEgg, tip);
                 picEasterEgg.Image = img;
                 picEasterEgg.Visible = true;
@@ -131,7 +131,7 @@ namespace Kbg.NppPluginNET
         //}
         private void OnLinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            LinkLabel lbl = (sender as LinkLabel);
+            LinkLabel lbl = sender as LinkLabel;
             string url = lbl.Text;
             string urlcopy = url;
             if ((string)lbl.Tag == "0")

--- a/CSVLintNppPlugin/Forms/ColumnSplitForm.cs
+++ b/CSVLintNppPlugin/Forms/ColumnSplitForm.cs
@@ -1,16 +1,11 @@
 ﻿using CSVLint;
 using Kbg.NppPluginNET;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 
 namespace CSVLintNppPlugin.Forms
 {
-    public partial class ColumnSplitForm : CSVLintNppPlugin.Forms.CsvEditFormBase
+    public partial class ColumnSplitForm : CsvEditFormBase
     {
         public ColumnSplitForm()
         {
@@ -37,11 +32,11 @@ namespace CSVLintNppPlugin.Forms
             cmbSelectColumn.SelectedIndex = idx;
 
             // which option selected
-            rdbtnSplitValid.Checked     = (Main.Settings.SplitOption == 0);
-            rdbtnSplitCharacter.Checked = (Main.Settings.SplitOption == 1);
-            rdbtnSplitSubstring.Checked = (Main.Settings.SplitOption == 2);
-            rdbtnSplitContains.Checked  = (Main.Settings.SplitOption == 3);
-            rdbtnSplitDecode.Checked    = (Main.Settings.SplitOption == 4);
+            rdbtnSplitValid.Checked     = Main.Settings.SplitOption == 0;
+            rdbtnSplitCharacter.Checked = Main.Settings.SplitOption == 1;
+            rdbtnSplitSubstring.Checked = Main.Settings.SplitOption == 2;
+            rdbtnSplitContains.Checked  = Main.Settings.SplitOption == 3;
+            rdbtnSplitDecode.Checked    = Main.Settings.SplitOption == 4;
 
             // load user preferences
             txtSplitCharacter.Text = Main.Settings.SplitChar;
@@ -60,16 +55,17 @@ namespace CSVLintNppPlugin.Forms
 
         private void OnRadioBtn_CheckedChanged(object sender, EventArgs e)
         {
+            if (!(sender is RadioButton radBut)) return;
             // which checkbox, see index in Tag property
-            bool chk = (sender as RadioButton).Checked;
-            ToggleControlBasedOnControl((sender as RadioButton), chk);
+            bool chk = radBut.Checked;
+            ToggleControlBasedOnControl(radBut, chk);
 
             EvaluateOkButton();
         }
         private void EvaluateOkButton()
         {
             // can not press OK when nothing selected
-            btnOk.Enabled = (cmbSelectColumn.SelectedIndex > 0);
+            btnOk.Enabled = cmbSelectColumn.SelectedIndex > 0;
         }
 
         private void ColumnSplitForm_FormClosing(object sender, FormClosingEventArgs e)
@@ -94,7 +90,7 @@ namespace CSVLintNppPlugin.Forms
             if (rdbtnSplitDecode.Checked)  { SplitParam1 = txtSplitDecode.Text; SplitParam2 = txtSplitDecodeChar.Text; }
 
             // remove original column
-            SplitRemove = (chkDeleteOriginal.Checked);
+            SplitRemove = chkDeleteOriginal.Checked;
         }
 
         private void btnOk_Click(object sender, EventArgs e)

--- a/CSVLintNppPlugin/Forms/CsvLintWindow.cs
+++ b/CSVLintNppPlugin/Forms/CsvLintWindow.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using CSVLint;
-using CSVLintNppPlugin.CsvLint;
 using CSVLintNppPlugin.Forms;
 using CsvQuery.PluginInfrastructure;
 using Kbg.NppPluginNET.PluginInfrastructure;
@@ -37,7 +32,7 @@ namespace Kbg.NppPluginNET
             // analyze and determine csv definition
             CsvDefinition csvdef = CsvAnalyze.InferFromData();
 
-            Main.updateCSVChanges(csvdef, false);
+            Main.UpdateCSVChanges(csvdef, false);
 
             var dtElapsed = (DateTime.Now - dtStart).ToString(@"hh\:mm\:ss\.fff");
 
@@ -45,7 +40,7 @@ namespace Kbg.NppPluginNET
             txtSchemaIni.Text = csvdef.GetIniLines();
 
             txtOutput.Clear();
-            txtOutput.Text = String.Format("Refresh from data is ready, time elapsed {0}", dtElapsed);
+            txtOutput.Text = string.Format("Refresh from data is ready, time elapsed {0}", dtElapsed);
         }
 
         private void OnBtnValidate_Click(object sender, EventArgs e)
@@ -82,8 +77,8 @@ namespace Kbg.NppPluginNET
 
             // variables
             int linenumber = 0;
-            TextBox log = (sender as TextBox);
-            String errval = "";
+            TextBox log = sender as TextBox;
+            string errval = "";
 
             // determine current line number in textbox
             int lineNumber = log.GetLineFromCharIndex(log.SelectionStart);
@@ -100,7 +95,7 @@ namespace Kbg.NppPluginNET
                     position += 13; // "** error line " is 14 characters
                     string logline = log.Text.Substring(position, lineEnd - position);
 
-                    Int32.TryParse(logline, out linenumber);
+                    int.TryParse(logline, out linenumber);
 
                     // find error value
                     position = log.Text.IndexOf(" value \"", lineEnd);
@@ -134,6 +129,7 @@ namespace Kbg.NppPluginNET
                 }
             }
         }
+
         private bool GetReformatParameters(out string dt, out string dec, out string sep, out bool updsep, out int updquote, out bool trimall, out bool alignVert)
         {
             // show reformat form
@@ -154,7 +150,7 @@ namespace Kbg.NppPluginNET
             frmedit.Dispose();
 
             // return true (OK) or false (Cancel)
-            return (r == DialogResult.OK);
+            return r == DialogResult.OK;
         }
 
         private void OnBtnReformat_Click(object sender, EventArgs e)
@@ -176,12 +172,12 @@ namespace Kbg.NppPluginNET
 
                 var dtElapsed = (DateTime.Now - dtStart).ToString(@"hh\:mm\:ss\.fff");
 
-                String msg = "";
+                string msg = "";
 
                 // refresh datadefinition
                 if (editDataTime != "")
                 {
-                    msg += String.Format("Reformat datetime format from \"{0}\" to \"{1}\"\r\n", csvdef.DateTimeFormat, editDataTime);
+                    msg += string.Format("Reformat datetime format from \"{0}\" to \"{1}\"\r\n", csvdef.DateTimeFormat, editDataTime);
                     csvdef.DateTimeFormat = editDataTime;
                     foreach (var col in csvdef.Fields)
                     {
@@ -191,14 +187,14 @@ namespace Kbg.NppPluginNET
 
                 if (editDecimal != "")
                 {
-                    msg += String.Format("Reformat decimal separator from {0} to {1}\r\n", csvdef.DecimalSymbol, editDecimal);
+                    msg += string.Format("Reformat decimal separator from {0} to {1}\r\n", csvdef.DecimalSymbol, editDecimal);
                     csvdef.DecimalSymbol = editDecimal[0];
                 };
 
                 if (updateSeparator)
                 {
-                    string oldsep = (csvdef.Separator == '\0' ? "{Fixed width}" : (csvdef.Separator == '\t' ? "{Tab}" : csvdef.Separator.ToString()));
-                    string newsep = (editSeparator == "\0" ? "{Fixed width}" : (editSeparator == "\t" ? "{Tab}" : editSeparator));
+                    string oldsep = csvdef.Separator == '\0' ? "{Fixed width}" : (csvdef.Separator == '\t' ? "{Tab}" : csvdef.Separator.ToString());
+                    string newsep = editSeparator == "\0" ? "{Fixed width}" : (editSeparator == "\t" ? "{Tab}" : editSeparator);
 
                     // fixed width doesn't contain header line (for example, columns can be width=1, no room in header line for column name longer than 1 character)
                     if (editSeparator == "\0")
@@ -206,7 +202,7 @@ namespace Kbg.NppPluginNET
                         csvdef.ColNameHeader = false;
                     }
 
-                    msg += String.Format("Reformat column separator from {0} to {1}\r\n", oldsep, newsep);
+                    msg += string.Format("Reformat column separator from {0} to {1}\r\n", oldsep, newsep);
                     csvdef.Separator = editSeparator[0];
                 };
 
@@ -216,7 +212,7 @@ namespace Kbg.NppPluginNET
                 }
 
                 // display process message
-                msg += String.Format("Reformat data is ready, time elapsed {0}\r\n", dtElapsed);
+                msg += string.Format("Reformat data is ready, time elapsed {0}\r\n", dtElapsed);
                 txtOutput.Text = msg;
 
                 // refresh datadefinition
@@ -241,7 +237,7 @@ namespace Kbg.NppPluginNET
             CsvDefinition csvdef = new CsvDefinition(txtSchemaIni.Text);
 
             // update the master list of csv definitions
-            Main.updateCSVChanges(csvdef, true);
+            Main.UpdateCSVChanges(csvdef, true);
 
             // update screen, to smooth out any user input errors
             SetCsvDefinition(csvdef);
@@ -260,8 +256,8 @@ namespace Kbg.NppPluginNET
             // user clicked OK or Cancel
             int cod = frmsplit.SplitCode;
             int idx = frmsplit.SplitColumn;
-            String par1 = frmsplit.SplitParam1;
-            String par2 = frmsplit.SplitParam2;
+            string par1 = frmsplit.SplitParam1;
+            string par2 = frmsplit.SplitParam2;
             bool rem = frmsplit.SplitRemove;
 
             // clear up
@@ -282,16 +278,16 @@ namespace Kbg.NppPluginNET
                 var dtElapsed = (DateTime.Now - dtStart).ToString(@"hh\:mm\:ss\.fff");
 
                 // ready message
-                String msg = "";
+                string msg = "";
                 if (cod == 1) msg = "invalid values";
                 if (cod == 2) msg = "character " + par1;
                 if (cod == 3) msg = "position " + par1;
                 if (cod == 4) msg = "when contains " + par1;
                 if (cod == 5) msg = "decode multiple value " + par1;
-                msg = String.Format("Column \"{0}\" was split on \"{1}\"\r\n", csvdef.Fields[idx].Name, msg);
+                msg = string.Format("Column \"{0}\" was split on \"{1}\"\r\n", csvdef.Fields[idx].Name, msg);
 
                 // display process message
-                msg += String.Format("Split column is ready, time elapsed {0}\r\n", dtElapsed);
+                msg += string.Format("Split column is ready, time elapsed {0}\r\n", dtElapsed);
                 txtOutput.Text = msg;
 
                 // refresh datadefinition

--- a/CSVLintNppPlugin/Forms/ReformatForm.cs
+++ b/CSVLintNppPlugin/Forms/ReformatForm.cs
@@ -33,15 +33,15 @@ namespace CSVLintNppPlugin.Forms
             cmbDecimal.Text   = Main.Settings.ReformatDecSep;
             cmbSeparator.Text = Main.Settings.ReformatColSep;
 
-            cmbQuotes.SelectedIndex = (Main.Settings.ReformatQuotes >= 0 && Main.Settings.ReformatQuotes < cmbQuotes.Items.Count ? Main.Settings.ReformatQuotes : 0);
+            cmbQuotes.SelectedIndex = Main.Settings.ReformatQuotes >= 0 && Main.Settings.ReformatQuotes < cmbQuotes.Items.Count ? Main.Settings.ReformatQuotes : 0;
 
             // load user preferences
-            chkDateTime.Checked    = (Main.Settings.ReformatOptions.IndexOf("1;") >= 0);
-            chkDecimal.Checked     = (Main.Settings.ReformatOptions.IndexOf("2;") >= 0);
-            chkSeparator.Checked   = (Main.Settings.ReformatOptions.IndexOf("3;") >= 0);
-            chkApplyQuotes.Checked = (Main.Settings.ReformatOptions.IndexOf("4;") >= 0);
-            chkTrimAll.Checked     = (Main.Settings.ReformatOptions.IndexOf("5;") >= 0);
-            chkAlignVert.Checked   = (Main.Settings.ReformatOptions.IndexOf("6;") >= 0);
+            chkDateTime.Checked    = Main.Settings.ReformatOptions.IndexOf("1;") >= 0;
+            chkDecimal.Checked     = Main.Settings.ReformatOptions.IndexOf("2;") >= 0;
+            chkSeparator.Checked   = Main.Settings.ReformatOptions.IndexOf("3;") >= 0;
+            chkApplyQuotes.Checked = Main.Settings.ReformatOptions.IndexOf("4;") >= 0;
+            chkTrimAll.Checked     = Main.Settings.ReformatOptions.IndexOf("5;") >= 0;
+            chkAlignVert.Checked   = Main.Settings.ReformatOptions.IndexOf("6;") >= 0;
 
             // enable/disable all
             OnChkbx_CheckedChanged(chkDateTime, null);
@@ -56,22 +56,22 @@ namespace CSVLintNppPlugin.Forms
         {
             // which checkbox, see index in Tag property
             bool chk = (sender as CheckBox).Checked;
-            ToggleControlBasedOnControl((sender as CheckBox), chk);
+            ToggleControlBasedOnControl(sender as CheckBox, chk);
 
             // can not press OK when nothing selected
-            btnOk.Enabled = (chkDateTime.Checked | chkDecimal.Checked | chkSeparator.Checked | chkApplyQuotes.Checked | chkTrimAll.Checked | chkAlignVert.Checked);
+            btnOk.Enabled = chkDateTime.Checked | chkDecimal.Checked | chkSeparator.Checked | chkApplyQuotes.Checked | chkTrimAll.Checked | chkAlignVert.Checked;
         }
 
         private void ReformatForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             // pass new values to previous form
-            NewDataTime  = (chkDateTime.Checked  ? cmbDateTime.Text : "");
-            NewDecimal   = (chkDecimal.Checked   ? cmbDecimal.Text : "");
-            NewSeparator = (chkSeparator.Checked ? cmbSeparator.Text : "");
-            UpdateSeparator = (chkSeparator.Checked);
-            ApplyQuotes     = (chkApplyQuotes.Checked ? cmbQuotes.SelectedIndex : 0);
-            TrimAllValues   = (chkTrimAll.Checked);
-            alignVertically = (chkAlignVert.Checked);
+            NewDataTime  = chkDateTime.Checked  ? cmbDateTime.Text : "";
+            NewDecimal   = chkDecimal.Checked   ? cmbDecimal.Text : "";
+            NewSeparator = chkSeparator.Checked ? cmbSeparator.Text : "";
+            UpdateSeparator = chkSeparator.Checked;
+            ApplyQuotes     = chkApplyQuotes.Checked ? cmbQuotes.SelectedIndex : 0;
+            TrimAllValues   = chkTrimAll.Checked;
+            alignVertically = chkAlignVert.Checked;
 
             // exception
             if (NewSeparator == "{Tab}") NewSeparator = "\t";
@@ -87,13 +87,13 @@ namespace CSVLintNppPlugin.Forms
             Main.Settings.ReformatQuotes     = cmbQuotes.SelectedIndex;
 
             // load user preferences
-            var opt = "";
-            opt += (chkDateTime.Checked     ? "1;" : "") +
-                    (chkDecimal.Checked     ? "2;" : "") +
-                    (chkSeparator.Checked   ? "3;" : "") +
-                    (chkApplyQuotes.Checked ? "4;" : "") +
-                    (chkTrimAll.Checked     ? "5;" : "") +
-                    (chkAlignVert.Checked   ? "6;" : "");
+            string opt =
+                (chkDateTime.Checked    ? "1;" : "") +
+                (chkDecimal.Checked     ? "2;" : "") +
+                (chkSeparator.Checked   ? "3;" : "") +
+                (chkApplyQuotes.Checked ? "4;" : "") +
+                (chkTrimAll.Checked     ? "5;" : "") +
+                (chkAlignVert.Checked   ? "6;" : "");
             Main.Settings.ReformatOptions = opt;
 
             // save to file

--- a/CSVLintNppPlugin/Forms/UniqueValuesForm.cs
+++ b/CSVLintNppPlugin/Forms/UniqueValuesForm.cs
@@ -2,15 +2,11 @@
 using Kbg.NppPluginNET;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 
 namespace CSVLintNppPlugin.Forms
 {
-    public partial class UniqueValuesForm : CSVLintNppPlugin.Forms.CsvEditFormBase
+    public partial class UniqueValuesForm : CsvEditFormBase
     {
         public UniqueValuesForm()
         {
@@ -40,12 +36,12 @@ namespace CSVLintNppPlugin.Forms
             listColumns_SelectedIndexChanged(listColumns, null);
 
             // load user preferences
-            chkSortBy.Checked      = (Main.Settings.UniqueSortBy);
-            radioSortValue.Checked = (Main.Settings.UniqueSortValue);
-            radioSortCount.Checked = (!Main.Settings.UniqueSortValue);
+            chkSortBy.Checked      = Main.Settings.UniqueSortBy;
+            radioSortValue.Checked = Main.Settings.UniqueSortValue;
+            radioSortCount.Checked = !Main.Settings.UniqueSortValue;
 
-            radioSortAsc.Checked = (Main.Settings.UniqueSortAsc);
-            radioSortDesc.Checked = (!Main.Settings.UniqueSortAsc);
+            radioSortAsc.Checked = Main.Settings.UniqueSortAsc;
+            radioSortDesc.Checked = !Main.Settings.UniqueSortAsc;
 
             // pre-select columns from previous
             var tmp = Main.Settings.UniqueColumns.Split('|');
@@ -58,21 +54,21 @@ namespace CSVLintNppPlugin.Forms
         private void listColumns_SelectedIndexChanged(object sender, EventArgs e)
         {
             // can not press OK when nothing selected
-            btnOk.Enabled = (listColumns.SelectedIndices.Count > 0);
+            btnOk.Enabled = listColumns.SelectedIndices.Count > 0;
         }
         private void chkSortBy_CheckedChanged(object sender, EventArgs e)
         {
             // which checkbox, see index in Tag property
             bool chk = (sender as CheckBox).Checked;
-            ToggleControlBasedOnControl((sender as CheckBox), chk);
+            ToggleControlBasedOnControl(sender as CheckBox, chk);
         }
 
         private void UniqueValuesForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             // pass new values to previous form
-            sortBy = (chkSortBy.Checked);
-            sortValue = (radioSortValue.Checked);
-            sortDesc = (radioSortDesc.Checked);
+            sortBy = chkSortBy.Checked;
+            sortValue = radioSortValue.Checked;
+            sortDesc = radioSortDesc.Checked;
 
             // indexes of selected columns
             columnIndexes = new List<int>();

--- a/CSVLintNppPlugin/Main.cs
+++ b/CSVLintNppPlugin/Main.cs
@@ -24,7 +24,6 @@ namespace Kbg.NppPluginNET
         public static CultureInfo dummyCulture;
 
         static string userConfigPath = null;
-        static bool checkdarkmode = false;
         static CsvLintWindow frmCsvLintDlg = null;
         static int idMyDlg = -1;
 
@@ -54,7 +53,8 @@ namespace Kbg.NppPluginNET
             // { ... }
 
             // changing tabs
-            if ((notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED) || (notification.Header.Code == (uint)NppMsg.NPPN_LANGCHANGED))
+            if ((notification.Header.Code == (uint)NppMsg.NPPN_BUFFERACTIVATED) ||
+                (notification.Header.Code == (uint)NppMsg.NPPN_LANGCHANGED))
             {
                 Main.CSVChangeFileTab();
             }
@@ -62,7 +62,7 @@ namespace Kbg.NppPluginNET
             // when closing a file
             if (notification.Header.Code == (uint)NppMsg.NPPN_FILEBEFORECLOSE)
             {
-                Main.removeCSVdef();
+                Main.RemoveCSVdef();
             }
         }
 
@@ -81,12 +81,12 @@ namespace Kbg.NppPluginNET
             //PluginBase.SetCommand(0, "MyMenuCommand", myMenuFunction, new ShortcutKey(false, false, false, Keys.None));
             PluginBase.SetCommand(0, "CSV Lint window", myDockableDialog); idMyDlg = 0;
             PluginBase.SetCommand(1, "---", null);
-            PluginBase.SetCommand(2, "Analyse data report", analyseDataReport);
+            PluginBase.SetCommand(2, "Analyse data report", AnalyseDataReport);
             PluginBase.SetCommand(3, "Count unique values", CountUniqueValues);
-            PluginBase.SetCommand(4, "Convert to SQL", convertToSQL);
+            PluginBase.SetCommand(4, "Convert to SQL", ConvertToSQL);
             PluginBase.SetCommand(5, "---", null);
-            PluginBase.SetCommand(6, "&Settings", doSettings);
-            PluginBase.SetCommand(7, "About / Help", doAboutForm);
+            PluginBase.SetCommand(6, "&Settings", DoSettings);
+            PluginBase.SetCommand(7, "About / Help", DoAboutForm);
 
             RefreshFromSettings();
         }
@@ -94,9 +94,9 @@ namespace Kbg.NppPluginNET
         internal static void RefreshFromSettings()
         {
             // the DateTime.TryParseExact requires a culture object, for much better performance DO NOT create on the fly for every call to EvaluateDateTime!
-            var tmp = (CultureInfo)(CultureInfo.InvariantCulture.Clone());
+            var tmp = (CultureInfo)CultureInfo.InvariantCulture.Clone();
             tmp.DateTimeFormat.Calendar.TwoDigitYearMax = Settings.intTwoDigitYearMax; // any cutoff you need
-                                                                // incorrect: tmp.Calendar.TwoDigitYearMax = 2039
+                                                        // incorrect: tmp.Calendar.TwoDigitYearMax = 2039
             dummyCulture = CultureInfo.ReadOnly(tmp);
         }
 
@@ -111,12 +111,12 @@ namespace Kbg.NppPluginNET
                 config.Load(xmlfile);
 
                 XmlNode darkmode = config.DocumentElement.SelectSingleNode("/NotepadPlus/GUIConfigs/GUIConfig[@name='DarkMode']");
-                darkmodeenabled = ((darkmode != null) && (darkmode as XmlElement).HasAttribute("enable") ? darkmode.Attributes["enable"].Value : "no");
+                darkmodeenabled = (darkmode != null) &&
+                    (darkmode as XmlElement).HasAttribute("enable") ? darkmode.Attributes["enable"].Value : "no";
             }
             catch { };
 
-            // return value
-            return (darkmodeenabled == "yes");
+            return darkmodeenabled == "yes";
         }
 
         internal static void TryCreateLexerXml(int presetidx, bool overwrite)
@@ -129,7 +129,7 @@ namespace Kbg.NppPluginNET
                 if (presetidx == -1)
                 {
                     // initially give users random color preset, i.e. distribute random among all users, to see which they like best
-                    var checkdarkmode = CheckConfigDarkMode();
+                    bool checkdarkmode = CheckConfigDarkMode();
                     var sec = DateTime.Now.Second % 2; // semi-random 0..1
                     presetidx = (checkdarkmode ? 2 : 0) + sec; // 0..1 for normal, 2..3 for dark mode
                 }
@@ -188,7 +188,7 @@ namespace Kbg.NppPluginNET
             };
 
             // Create an XmlWriterSettings object with the correct options.
-            System.Xml.XmlWriterSettings xmlsettings = new System.Xml.XmlWriterSettings();
+            XmlWriterSettings xmlsettings = new XmlWriterSettings();
             xmlsettings.Indent = true;
             xmlsettings.IndentChars = "\t"; //  "\t";
             xmlsettings.OmitXmlDeclaration = false;
@@ -197,7 +197,7 @@ namespace Kbg.NppPluginNET
 
             try
             {
-                using (System.Xml.XmlWriter writer = System.Xml.XmlWriter.Create(filename, xmlsettings))
+                using (XmlWriter writer = XmlWriter.Create(filename, xmlsettings))
                 {
 
                     writer.WriteStartDocument();
@@ -247,10 +247,10 @@ namespace Kbg.NppPluginNET
                                 //writer.WriteAttributeString("fontName", "");
                                 //writer.WriteAttributeString("fontStyle", "0");
                             //writer.WriteEndElement();
-                            var name = (i == 0 ? "Default" : "ColumnColor" + i.ToString());
+                            var name = i == 0 ? "Default" : "ColumnColor" + i.ToString();
                             var fgcolor = colors[coloridx];
                             var bgcolor = colors[coloridx + 1];
-                            var bold = (ps == 0 || i == 0 ? "0" : "1");
+                            var bold = ps == 0 || i == 0 ? "0" : "1";
                             var str = string.Format("\r\n\t\t\t<WordsStyle styleID=\"{0}\" name=\"{1}\" fgColor=\"{2}\" bgColor=\"{3}\" fontName=\"\" fontStyle=\"{4}\" />", i, name, fgcolor, bgcolor, bold);
                             writer.WriteRaw(str);
 
@@ -265,7 +265,7 @@ namespace Kbg.NppPluginNET
 
                     writer.Flush();
                     writer.Close();
-                } // End Using writer 
+                } // End Using writer
             }
             catch
             {
@@ -306,7 +306,7 @@ namespace Kbg.NppPluginNET
             string filename = notepad.GetCurrentFilePath();
 
             // check if already in list
-            if (!FileCsvDef.ContainsKey(filename))
+            if (!FileCsvDef.TryGetValue(filename, out csvdef))
             {
                 // read schema.ini file
                 var lines = CsvSchemaIni.ReadIniSection(filename);
@@ -322,14 +322,10 @@ namespace Kbg.NppPluginNET
                 }
                 FileCsvDef.Add(filename, csvdef);
             }
-            else
-            {
-                csvdef = FileCsvDef[filename];
-            }
 
             // pass separator to lexer
             string sepchar = csvdef.Separator.ToString();
-            string sepcol = (Settings.SeparatorColor ? "1" : "0");
+            string sepcol = Settings.SeparatorColor ? "1" : "0";
             editor.SetProperty("separator", sepchar);
             editor.SetProperty("separatorcolor", sepcol);
 
@@ -356,27 +352,18 @@ namespace Kbg.NppPluginNET
             }
         }
 
-        public static void updateCSVChanges(CsvDefinition csvdef, bool saveini)
+        public static void UpdateCSVChanges(CsvDefinition csvdef, bool saveini)
         {
             // Notepad++ switc to a different file tab
             INotepadPPGateway notepad = new NotepadPPGateway();
             string filename = notepad.GetCurrentFilePath();
 
-            // check if already in list
-            if (!FileCsvDef.ContainsKey(filename))
-            {
-                // add csv definition
-                FileCsvDef.Add(filename, csvdef);
-            }
-            else
-            {
-                // overwrite old csv definition with new
-                FileCsvDef[filename] = csvdef;
-            }
+            // overwrite old or add new csv definition
+            FileCsvDef[filename] = csvdef;
 
             // pass separator to lexer
             string sepchar = csvdef.Separator.ToString();
-            string sepcol = (Settings.SeparatorColor ? "1" : "0");
+            string sepcol = Settings.SeparatorColor ? "1" : "0";
             editor.SetProperty("separator", sepchar);
             editor.SetProperty("separatorcolor", sepcol);
 
@@ -409,43 +396,31 @@ namespace Kbg.NppPluginNET
             INotepadPPGateway notepad = new NotepadPPGateway();
             string filename = notepad.GetCurrentFilePath();
 
-            // check if already in list
-            if (FileCsvDef.ContainsKey(filename))
-            {
-                return FileCsvDef[filename];
-            }
-
-            return null;
+            return FileCsvDef.TryGetValue(filename, out CsvDefinition result) ? result : null;
         }
 
-        public static void removeCSVdef()
+        public static void RemoveCSVdef()
         {
             // Notepad++ closes a file, also remove the definition from list
             INotepadPPGateway notepad = new NotepadPPGateway();
             string filename = notepad.GetCurrentFilePath();
 
-            // check if in list
-            if (FileCsvDef.ContainsKey(filename))
-            {
-                // remove csv definition
-                FileCsvDef.Remove(filename);
-            }
+            // remove csv definition if existant
+            FileCsvDef.Remove(filename);
         }
 
         public static void GetCurrentFileLexerParameters(out char sep)
         {
-
             sep = ';';
 
             // Notepad++ switc to a different file tab
             INotepadPPGateway notepad = new NotepadPPGateway();
+            string filename = notepad.GetCurrentFilePath();
 
             CsvDefinition csvdef;
 
-            string filename = notepad.GetCurrentFilePath();
-
             // check if already in list
-            if (!FileCsvDef.ContainsKey(filename))
+            if (!FileCsvDef.TryGetValue(filename, out csvdef))
             {
                 // read schema.ini file
                 var lines = CsvSchemaIni.ReadIniSection(filename);
@@ -462,10 +437,6 @@ namespace Kbg.NppPluginNET
 
                 FileCsvDef.Add(filename, csvdef);
             }
-            else
-            {
-                csvdef = FileCsvDef[filename];
-            }
             sep = csvdef.Separator;
         }
 
@@ -473,28 +444,25 @@ namespace Kbg.NppPluginNET
         {
             // any clean up code here
         }
-        internal static void doSettings()
+
+        internal static void DoSettings()
         {
             Settings.ShowDialog();
             RefreshFromSettings();
         }
 
-        internal static void doAboutForm()
+        internal static void DoAboutForm()
         {
-            var about = new AboutForm();
-            about.ShowDialog();
-            about.Dispose();
+            using (var about = new AboutForm())
+                about.ShowDialog();
         }
 
-        internal static void convertToSQL()
+        internal static void ConvertToSQL()
         {
-            // get dictionary
-            CsvDefinition csvdef = GetCurrentCsvDef();
-
-            CsvEdit.ConvertToSQL(csvdef);
+            CsvEdit.ConvertToSQL(GetCurrentCsvDef());
         }
 
-        internal static void analyseDataReport()
+        internal static void AnalyseDataReport()
         {
             // get dictionary
             CsvDefinition csvdef = GetCurrentCsvDef();
@@ -576,19 +544,19 @@ namespace Kbg.NppPluginNET
             else
             {
                 // toggle on/off
-                if (!frmCsvLintDlg.Visible)
-                    Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_DMMSHOW, 0, frmCsvLintDlg.Handle); // show
-                else
-                    Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_DMMHIDE, 0, frmCsvLintDlg.Handle); // hide
+                Win32.SendMessage(PluginBase.nppData._nppHandle,
+                    (uint)(frmCsvLintDlg.Visible ? NppMsg.NPPM_DMMHIDE : NppMsg.NPPM_DMMSHOW),
+                    0, frmCsvLintDlg.Handle);
             }
 
             // immediately show currnet csv metadata when activated
             CSVChangeFileTab();
         }
+
         public static string GetVersion()
         {
             // version for example "1.3.0.0"
-            String ver = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            string ver = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 
             // if 4 version digits, remove last two ".0" if any, example  "1.3.0.0" ->  "1.3" or  "2.0.0.0" ->  "2.0"
             while ((ver.Length > 4) && (ver.Substring(ver.Length - 2, 2) == ".0"))

--- a/CSVLintNppPlugin/Main.cs
+++ b/CSVLintNppPlugin/Main.cs
@@ -320,12 +320,11 @@ namespace Kbg.NppPluginNET
 
         public static void CSVChangeFileTab()
         {
-            // Notepad++ switch to a different file tab
+            // Notepad++ switched to a different file tab
             INotepadPPGateway notepad = new NotepadPPGateway();
+            string filename = notepad.GetCurrentFilePath();
 
             CsvDefinition csvdef;
-
-            string filename = notepad.GetCurrentFilePath();
 
             // check if already in list
             if (!FileCsvDef.TryGetValue(filename, out csvdef))
@@ -433,6 +432,7 @@ namespace Kbg.NppPluginNET
             FileCsvDef.Remove(filename);
         }
 
+        [Obsolete("There is no reference to this in the CsvLintSolution. If used from elsewhere please add in summary.", false)]
         public static void GetCurrentFileLexerParameters(out char sep)
         {
             sep = ';';

--- a/CSVLintNppPlugin/PluginInfrastructure/Lexer.cs
+++ b/CSVLintNppPlugin/PluginInfrastructure/Lexer.cs
@@ -22,7 +22,7 @@ namespace NppPluginNET.PluginInfrastructure
             { "fold.compact", false},
             { "separatorcolor", false},
             { "separator", false}
-    };
+        };
         static readonly Dictionary<string, string> PropertyDescription = new Dictionary<string, string>
         {
             { "fold", "Enable or disable the folding functionality."},
@@ -368,7 +368,7 @@ namespace NppPluginNET.PluginInfrastructure
             }
             else if (name == "fixedwidths")
             {
-                fixedWidths = value.Split(',').Select(Int32.Parse).ToList();
+                fixedWidths = value.Split(',').Select(int.Parse).ToList();
                 separatorChar = '\0';
             }
             else
@@ -472,7 +472,7 @@ namespace NppPluginNET.PluginInfrastructure
 
                         // next color, cycle colors or reset at end of line
                         idx++;
-                        if ((idx > 8) || (isEOL)) idx = 1;
+                        if ((idx > 8) || isEOL) idx = 1;
 
                         // next width, or take the rest after last column width 
                         if (colidx < fixedWidths.Count)
@@ -506,7 +506,7 @@ namespace NppPluginNET.PluginInfrastructure
                     if (!quote)
                     {
                         // to catch where value is just two quotes "" right at start of line
-                        bool cellIsEmpty = (i - start_col == 0);
+                        bool cellIsEmpty = i - start_col == 0;
 
                         // check if starting a quoted value or going next column or going to next line
                         if ((cur == quote_char) && cellIsEmpty) { quote = true; }
@@ -543,7 +543,7 @@ namespace NppPluginNET.PluginInfrastructure
                         // next color
                         idx++;
 
-                        if ((idx > 8) || (isEOL)) idx = 1; // reset end of line
+                        if ((idx > 8) || isEOL) idx = 1; // reset end of line
 
                         bNextCol = false;
                         isEOL = false;

--- a/CSVLintNppPlugin/PluginInfrastructure/Lexer.cs
+++ b/CSVLintNppPlugin/PluginInfrastructure/Lexer.cs
@@ -269,6 +269,9 @@ namespace NppPluginNET.PluginInfrastructure
         static ILexer4 ilexer4 = new ILexer4 { };
         static IntPtr vtable_pointer = IntPtr.Zero;
 
+        private static Colour sCaretLineBack = new Colour(
+            Main.CheckConfigDarkMode() ? 0xFFFFFF: 0); // 0);// 
+
         public static IntPtr ILexerImplementation()
         {
             if (vtable_pointer == IntPtr.Zero)
@@ -409,6 +412,16 @@ namespace NppPluginNET.PluginInfrastructure
 
             int length = (int)length_doc;
             int start = (int)start_pos;
+
+            // create transparent cursor line
+            if (start == 0 && PluginBase.MainScintillaActive
+                && !Main.sShouldResetCaretBack)
+            {
+                var editor = new ScintillaGateway(PluginBase.GetCurrentScintilla());
+                editor.SetCaretLineBackAlpha((Alpha)16+8);
+                editor.SetCaretLineBack(sCaretLineBack);
+                Main.sShouldResetCaretBack = true;
+            }
 
             // allocate a buffer
             IntPtr buffer_ptr = Marshal.AllocHGlobal(length);

--- a/CSVLintNppPlugin/PluginInfrastructure/NppPluginNETBase.cs
+++ b/CSVLintNppPlugin/PluginInfrastructure/NppPluginNETBase.cs
@@ -37,11 +37,20 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
             _funcItems.Add(funcItem);
         }
 
+        internal static bool MainScintillaActive
+        {
+            get
+            {
+                int curScintilla;
+                Win32.SendMessage(nppData._nppHandle,
+                    (uint)NppMsg.NPPM_GETCURRENTSCINTILLA, 0, out curScintilla);
+                return curScintilla == 0;
+            }
+        }
+
         internal static IntPtr GetCurrentScintilla()
         {
-            int curScintilla;
-            Win32.SendMessage(nppData._nppHandle, (uint) NppMsg.NPPM_GETCURRENTSCINTILLA, 0, out curScintilla);
-            return (curScintilla == 0) ? nppData._scintillaMainHandle : nppData._scintillaSecondHandle;
+            return MainScintillaActive ? nppData._scintillaMainHandle : nppData._scintillaSecondHandle;
         }
 
 

--- a/CSVLintNppPlugin/PluginInfrastructure/SettingsBase.cs
+++ b/CSVLintNppPlugin/PluginInfrastructure/SettingsBase.cs
@@ -192,7 +192,7 @@ namespace CsvQuery.PluginInfrastructure
 
             var dialog = new Form
             {
-                Text = String.Format("Settings - {0} plug-in", Main.PluginName),
+                Text = string.Format("Settings - {0} plug-in", Main.PluginName),
                 ClientSize = new Size(DEFAULT_WIDTH, DEFAULT_HEIGHT),
                 MinimumSize = new Size(250, 250),
                 ShowIcon = false,

--- a/CSVLintNppPlugin/Tools/Settings.cs
+++ b/CSVLintNppPlugin/Tools/Settings.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.ComponentModel;
 using CsvQuery.PluginInfrastructure;
 using System.Text.RegularExpressions;
@@ -14,30 +10,38 @@ namespace Kbg.NppPluginNET
     /// </summary>
     public class Settings : SettingsBase
     {
-        [Description("Maximum unique values when reporting or detecting coded values, if column contains more than it's not reported."), Category("Analyze"), DefaultValue(15)]
+        [Description("Maximum unique values when reporting or detecting coded values, if column contains more than it's not reported."),
+            Category("Analyze"), DefaultValue(15)]
         public int UniqueValuesMax { get; set; }
 
-        //[Description("Maximum rows to analyze to automatically detect data types. Set to 0 to analyze all rows, set to 1000 for better performance with large files."), Category("Analyze"), DefaultValue(0)]
+        //[Description("Maximum rows to analyze to automatically detect data types. Set to 0 to analyze all rows, set to 1000 for better performance with large files."),
+        //    Category("Analyze"), DefaultValue(0)]
         //public int ScanRows { get; set; }
-		
-        [Description("Maximum amount of digits for integer values, if a value has more then it's considered a text value. Applies to both autodetecting datatypes and validating data. Useful to distinguish (bar)codes and actual numeric values."), Category("Analyze"), DefaultValue(12)]
+
+        [Description("Maximum amount of digits for integer values, if a value has more then it's considered a text value. Applies to both autodetecting datatypes and validating data. Useful to distinguish (bar)codes and actual numeric values."),
+            Category("Analyze"), DefaultValue(12)]
         public int IntegerDigitsMax { get; set; }
 
-        [Description("Maximum amount of decimals for decimal values, if a value has more then it's considered a text value. Applies to both autodetecting datatypes and validating data."), Category("Analyze"), DefaultValue(20)]
+        [Description("Maximum amount of decimals for decimal values, if a value has more then it's considered a text value. Applies to both autodetecting datatypes and validating data."),
+            Category("Analyze"), DefaultValue(20)]
         public int DecimalDigitsMax { get; set; }
 
-        [Description("Decimal values must have leading zero, set to false to accept values like .5 or .01"), Category("Analyze"), DefaultValue(true)]
+        [Description("Decimal values must have leading zero, set to false to accept values like .5 or .01"),
+            Category("Analyze"), DefaultValue(true)]
         public bool DecimalLeadingZero { get; set; }
 
-        [Description("When detecting or validating date or datetime values, years smaller than this value will be considered as out-of-range."), Category("Analyze"), DefaultValue(1900)]
+        [Description("When detecting or validating date or datetime values, years smaller than this value will be considered as out-of-range."),
+            Category("Analyze"), DefaultValue(1900)]
         public int YearMinimum { get; set; }
 
-        [Description("When detecting or validating date or datetime values, years larger than this value will be considered as out-of-range."), Category("Analyze"), DefaultValue(2050)]
+        [Description("When detecting or validating date or datetime values, years larger than this value will be considered as out-of-range."),
+            Category("Analyze"), DefaultValue(2050)]
         public int YearMaximum { get; set; }
 
         private int _sqlbatch;
 
-        [Description("Maximum records per SQL insert batch, minimum batch size is 10."), Category("Edit"), DefaultValue(1000)]
+        [Description("Maximum records per SQL insert batch, minimum batch size is 10."),
+            Category("Edit"), DefaultValue(1000)]
         public int SQLBatchRows
         {
             get { return _sqlbatch; }
@@ -47,11 +51,13 @@ namespace Kbg.NppPluginNET
             }
         }
 
-        [Description("Convert to ANSI standard SQL script, set to true for mySQL or false for MS-SQL."), Category("Edit"), DefaultValue(true)]
+        [Description("Convert to ANSI standard SQL script, set to true for mySQL or false for MS-SQL."),
+            Category("Edit"), DefaultValue(true)]
         public bool SQLansi { get; set; }
 
-        [Description("Maximum year for two digit year date values. For example, when set to 2024 the year values 24 and 25 will be interpreted as 2024 and 1925. Set as SysYear for current year."), Category("Edit"), DefaultValue("SysYear")]
-        public String TwoDigitYearMax
+        [Description("Maximum year for two digit year date values. For example, when set to 2024 the year values 24 and 25 will be interpreted as 2024 and 1925. Set as SysYear for current year."),
+            Category("Edit"), DefaultValue("SysYear")]
+        public string TwoDigitYearMax
         {
             get
             {
@@ -60,30 +66,34 @@ namespace Kbg.NppPluginNET
             set
             {
                 // set string representation, may include "SysYear"
-                this._strTwoDigitYearMax = this.checkYearString(value);
+                this._strTwoDigitYearMax = this.CheckYearString(value);
                 // set actual integer value
-                this.intTwoDigitYearMax = this.getYearFromString(value);
+                this.intTwoDigitYearMax = this.GetYearFromString(value);
             }
         }
 
         // actual year value as int
         public int intTwoDigitYearMax;
-        private String _strTwoDigitYearMax;
+        private string _strTwoDigitYearMax;
 
         //[Description("Decimal values remove leading zero, for example output 0.5 as .5"), Category("Edit"), DefaultValue(false)]
         //public bool DecimalLeadingZeroOut { get; set; }
 
-        [Description("Default quote escape character when quotes exists inside text"), Category("General"), DefaultValue('"')]
+        [Description("Default quote escape character when quotes exists inside text"),
+            Category("General"), DefaultValue('"')]
         public char DefaultQuoteChar { get; set; }
 
-        [Description("Keyword for empty values or null values in the csv data, case-sensitive."), Category("General"), DefaultValue("NaN")]
-        public String NullValue { get; set; }
+        [Description("Keyword for empty values or null values in the csv data, case-sensitive."),
+            Category("General"), DefaultValue("NaN")]
+        public string NullValue { get; set; }
 
-        [Description("Include separator in syntax highlighting colors. Set to false and the separator characters are not colored."), Category("General"), DefaultValue(false)]
+        [Description("Include separator in syntax highlighting colors. Set to false and the separator characters are not colored."),
+            Category("General"), DefaultValue(false)]
         public bool SeparatorColor { get; set; }
 
-        [Description("Preferred characters when automatically detecting the separator character. For special characters like tab, use \\t or \\u0009."), Category("General"), DefaultValue(",;\\t|")]
-        public String Separators
+        [Description("Preferred characters when automatically detecting the separator character. For special characters like tab, use \\t or \\u0009."),
+            Category("General"), DefaultValue(",;\\t|")]
+        public string Separators
         {
             get
             {
@@ -106,7 +116,7 @@ namespace Kbg.NppPluginNET
                     char c = '\0';
                     if (ItemMatch.Length > 1)
                     {
-                        String ltr = ItemMatch.ToString().Substring(1, 1);
+                        string ltr = ItemMatch.ToString().Substring(1, 1);
 
                         // check for default characters
                         if (ltr == "t") c = '\t'; // tab
@@ -118,7 +128,7 @@ namespace Kbg.NppPluginNET
                         // check for u0009 or x09 etc.
                         if ((ltr == "u") || (ltr == "x") )
                         {
-                            String hexnr = ItemMatch.ToString().Substring(2, ItemMatch.Length - 2);
+                            string hexnr = ItemMatch.ToString().Substring(2, ItemMatch.Length - 2);
                             int number = Convert.ToInt32(hexnr, 16);
                             c = Convert.ToChar(number);
                         }
@@ -136,26 +146,32 @@ namespace Kbg.NppPluginNET
             }
         }
         // actual year value as int
-        public String _charSeparators;
-        private String _strSeparators;
+        public string _charSeparators;
+        private string _strSeparators;
 
-        [Description("Trim values before analyzing or editing, only applies to csv because for fixed width data it is always trimmed internally."), Category("General"), DefaultValue(true)]
+        [Description("Trim values before analyzing or editing, only applies to csv because for fixed width data it is always trimmed internally."),
+            Category("General"), DefaultValue(true)]
         public bool TrimValues { get; set; }
 
-        //[Description("Maximum errors output, limit errors logging, or 0 for no limit."), Category("Validate"), DefaultValue(0)]
+        //[Description("Maximum errors output, limit errors logging, or 0 for no limit."),
+        //    Category("Validate"), DefaultValue(0)]
         //public int MaxErrors { get; set; }
 
-        //[Description("Month abbreviations for detecting or generating date format 'mmmm', comma separated list of 12 names."), Category("Validate"), DefaultValue("jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec")]
+        //[Description("Month abbreviations for detecting or generating date format 'mmmm', comma separated list of 12 names."),
+        //    Category("Validate"), DefaultValue("jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec")]
         //public String MonthAbbrev { get; set; }
 
         // SPLIT COLUMN user preferences
-        [Description("Split column, selected column name."), Category("UserPref"), DefaultValue("")]
-        public String SplitColName { get; set; }
+        [Description("Split column, selected column name."),
+            Category("UserPref"), DefaultValue("")]
+        public string SplitColName { get; set; }
 
-        [Description("Split column, selected option."), Category("UserPref"), DefaultValue(0)]
+        [Description("Split column, selected option."),
+            Category("UserPref"), DefaultValue(0)]
         public int SplitOption { get; set; }
 
-        [Description("Split column, split on character."), Category("UserPref"), DefaultValue("/")]
+        [Description("Split column, split on character."),
+            Category("UserPref"), DefaultValue("/")]
         public string SplitChar { get; set; }
 
         [Description("Split column, split on position."), Category("UserPref"), DefaultValue(3)]
@@ -203,7 +219,7 @@ namespace Kbg.NppPluginNET
         public bool UniqueSortAsc { get; set; }
 
         // helper function for "SysYear" as year values
-        private int getYearFromString(String yr)
+        private int GetYearFromString(string yr)
         {
             // test if it's a valid int
             int.TryParse(yr, out int ret);
@@ -216,9 +232,10 @@ namespace Kbg.NppPluginNET
 
             return ret;
         }
-        private String checkYearString(String yr)
+
+        private string CheckYearString(string yr)
         {
-            String ret = yr.Trim();
+            string ret = yr.Trim();
 
             // test if it's a valid int
             int.TryParse(ret, out int test);


### PR DESCRIPTION
I performed some changes suggested by Visual Studio 2017 like:
- String -> string
- remove obsolete using directives
- remove unneeded brackets
- correct casing (to what MS thinks is correct)

I simplified some Dictionary<,> related things:
1. for "AddOrOverwrite" one can simply use **dict[key]=value**. When first checking,
   whether a key exists and adding if not, the dictionary would check another time.
2. For checking existence and retrieving a value it is easier and faster to use **TryGetValue**

In ColAsString in CsvAnalyzeColumn.cs I made use of Enum.GetName() which will continue to work if the Enum will be enhanced. This led to only string concatenation which was replaced by string.Format.

Further I replaced **string.Format("{0}\\{1}", path, file)** with **Path.Combine(path, file)** so that this would work on other OSes like e.g. Linux too.

I removed the indentation of some XML comments almost automatically. It came to my mind later, that the indentation actually might have a meaning for you.