### PR TITLE
Change TransparentCursor default to false

### DIFF
--- a/CSVLintNppPlugin/Tools/Settings.cs
+++ b/CSVLintNppPlugin/Tools/Settings.cs
@@ -179,7 +179,7 @@ namespace Kbg.NppPluginNET
         public string _charSeparators;
         private string _strSeparators;
 
-        [Description("Transparent cursor line, changing this setting will require a restart of Notepad++."), Category("General"), DefaultValue(true)]
+        [Description("Transparent cursor line, changing this setting will require a restart of Notepad++. Note: enabling this can make the caret line and text selections hard to see or invisible, especially with dark themes, see issues #68 and #77."), Category("General"), DefaultValue(false)]
         public bool TransparentCursor { get; set; }
 
         //[Description("Maximum errors output, limit errors logging, or 0 for no limit."),

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -708,7 +708,7 @@ and they are stored in a settings file `%USERPROFILE%\AppData\Roaming\Notepad++\
 | NullKeyword      | A case-sensitive keyword that will be treated as an empty value, typically `NULL`, `NaN`, `NA` or `None` depending on your data | NaN     |
 | SeparatorColor   | Include separator in syntax highlighting colors. Set to false and the separator characters are always white.    | false   |
 | Separators       | Preferred characters when automatically detecting the separator character. For special characters like tab, use \\t or hexadecimal escape sequence \\u0009 or \\x09. | ,;\t&#124; |
-| TransparentCursor| Transparent cursor line, changing this setting will require a restart of Notepad++                              | true    |
+| TransparentCursor| Transparent cursor line, changing this setting will require a restart of Notepad++. Note: enabling this can make the caret line and text selections hard to see or invisible, especially with dark themes. | false   |
 | UserPref section | Various input settings for the CSV Lint dialogs for Convert Data, Reformat, Split Column etc.                   |         |
 
 About


### PR DESCRIPTION
Fixes the out-of-the-box symptom of #68 and #77; also the cause of notepad-plus-plus/notepad-plus-plus#17192 (closed there as a plugin issue).

### What

Flips the `TransparentCursor` default from `true` to `false` (one attribute change in `Settings.cs`, seeded via `SettingsBase`), and documents the risk in the setting description and `docs/readme.md`.

### Why

The transparent cursor line is applied globally at plugin load, for all file types, using the legacy `SCI_SETCARETLINEBACKALPHA` API with a hardcoded black colour. Notepad++ ≥ 8.4 manages the caret line via Scintilla 5 element colors, so any restyle event (theme change, opening the Style Configurator, dark-mode toggle, other plugins) leaves a mixed state: a black or invisible caret line and masked text selections — worst in dark themes. The `GetCaretLineBackAlpha() == NOALPHA` guard then prevents recovery until Notepad++ is restarted.

Since the feature is currently on by default, every new install is exposed to this even if the user never opens a CSV file. Defaulting to `false` makes new installs safe while keeping the feature available as an opt-in. **Existing users are unaffected** — `SettingsBase` only uses `DefaultValue` when no value is present in the saved ini, so anyone who has run the plugin before keeps their current setting.

A proper fix for the feature itself (element-color API, scoping to CSV buffers, handling `NPPN_WORDSTYLESUPDATED`) can follow separately; this PR just stops the default-configuration breakage.

### Changes

- `CSVLintNppPlugin/Tools/Settings.cs`: `DefaultValue(true)` → `DefaultValue(false)` on `TransparentCursor`; description now warns about the visibility problem.
- `docs/readme.md`: settings table updated to match (default `false`, warning note).
